### PR TITLE
feat: add workflow and mental health insights

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,6 +535,19 @@
         col.appendChild(div);
       }
     }
+    // click to advance pipeline stage
+    if(pipelineBoard){
+      pipelineBoard.addEventListener('click',e=>{
+        const card=e.target.closest('.task');
+        if(!card) return;
+        const stages=['Lead','Proposal','Won'];
+        const current=card.parentElement.dataset.stage;
+        let idx=stages.indexOf(current);
+        idx=(idx+1)%stages.length;
+        const nextCol=pipelineBoard.querySelector(`.column[data-stage='${stages[idx]}']`);
+        if(nextCol) nextCol.appendChild(card);
+      });
+    }
 
     // Clients table
     const addClientBtn = document.getElementById('add-client');
@@ -759,20 +772,23 @@
         }
       });
 
-      // Daily tasks
+    // Daily tasks
       const dailyList = document.getElementById('daily-list');
+      const todayStr = new Date().toISOString().split('T')[0];
       let dailyTasks = [];
       function loadDaily(){
         const saved = localStorage.getItem('daily-tasks');
         if(saved){ try{ dailyTasks = JSON.parse(saved); }catch{ dailyTasks=[]; } }
         if(!dailyTasks.length){
           dailyTasks = [
-            {id:1,title:'Call: Jordan Lee (Acme Co.)',due:'2024-09-02',checked:false},
-            {id:2,title:'Call: Priya Shah (Blue Sky Studio)',due:'2024-09-02',checked:false},
-            {id:3,title:'Call: Alex Rivera (Zenith Group)',due:'2024-09-02',checked:false},
-            {id:4,title:'Wellness: Stretch for 5 minutes',due:'',checked:false},
-            {id:5,title:'Wellness: Drink water (250 ml)',due:'',checked:false}
+            {id:1,title:'Call: Jordan Lee (Acme Co.)',due:todayStr,checked:false},
+            {id:2,title:'Call: Priya Shah (Blue Sky Studio)',due:todayStr,checked:false},
+            {id:3,title:'Call: Alex Rivera (Zenith Group)',due:todayStr,checked:false},
+            {id:4,title:'Wellness: Stretch for 5 minutes',due:todayStr,checked:false},
+            {id:5,title:'Wellness: Drink water (250 ml)',due:todayStr,checked:false}
           ];
+        } else {
+          dailyTasks = dailyTasks.map(t=>({...t, due: t.due || todayStr}));
         }
       }
       function saveDaily(){ localStorage.setItem('daily-tasks', JSON.stringify(dailyTasks)); }
@@ -783,20 +799,22 @@
           const div=document.createElement('div');
           div.className='task'+(t.checked?' checked':'');
           div.dataset.id=t.id;
-          div.innerHTML=`<div style="display:flex;align-items:center;gap:6px;"><div class="checkbox ${t.checked?'checked':''}" data-check></div><div contenteditable class="task-title">${t.title}</div></div><div class="mini">Due: <span contenteditable class="task-due">${t.due||''}</span></div>`;
+          div.innerHTML=`<div style="display:flex;align-items:center;gap:6px;"><div class="checkbox ${t.checked?'checked':''}" data-check></div><div contenteditable class="task-title">${t.title}</div></div><div class="mini">Due: <input type="date" class="task-due" value="${t.due||todayStr}" /></div>`;
           dailyList.appendChild(div);
         });
       }
       const addDaily=document.getElementById('daily-add');
+      const dailyDueInput=document.getElementById('daily-new-due');
+      if(dailyDueInput){ dailyDueInput.value=todayStr; }
       if(addDaily){
         addDaily.addEventListener('click',()=>{
           const title=document.getElementById('daily-new-title').value.trim();
-          const due=document.getElementById('daily-new-due').value;
+          const due=dailyDueInput.value||todayStr;
           if(!title) return;
           dailyTasks.push({id:Date.now(),title,due,checked:false});
           saveDaily(); renderDaily();
           document.getElementById('daily-new-title').value='';
-          document.getElementById('daily-new-due').value='';
+          dailyDueInput.value=todayStr;
         });
       }
       loadDaily();
@@ -817,12 +835,13 @@
           updateInsights();
           renderWorkflow();
         }else{
-          const d = dailyTasks.find(t=>t.id===id);
-          if(d){
-            d.title = taskEl.querySelector('.task-title').textContent.trim();
-            d.due = taskEl.querySelector('.task-due')?.textContent.trim() || '';
-            saveDaily();
-          }
+            const d = dailyTasks.find(t=>t.id===id);
+            if(d){
+              d.title = taskEl.querySelector('.task-title').textContent.trim();
+              const dueInput = taskEl.querySelector('.task-due');
+              d.due = dueInput ? dueInput.value : todayStr;
+              saveDaily();
+            }
         }
       }, true);
 
@@ -919,7 +938,8 @@
           const y=h-barH;
           ctx.fillStyle=color;
           ctx.fillRect(x,y,bw,barH);
-          barData[id].push({x,y,w:bw,h:barH,label:labels[i],value:v});
+          const displayVal = id==='workflow-chart'? v*20 : v;
+          barData[id].push({x,y,w:bw,h:barH,label:labels[i],value:displayVal});
         });
         if(!ctx.canvas.dataset.tooltipAttached){
           ctx.canvas.addEventListener('mousemove',e=>{
@@ -928,7 +948,9 @@
             const bar=barData[id].find(b=>x>=b.x && x<=b.x+b.w && y>=b.y && y<=b.y+b.h);
             if(bar){
               tooltip.style.display='block';
-              tooltip.textContent=`${bar.label}: ${bar.value} tasks`;
+              tooltip.textContent = id==='workflow-chart'
+                ? `${bar.label}: ${bar.value}% complete`
+                : `${bar.label}: ${bar.value} tasks`;
               tooltip.style.left=(e.clientX+10)+'px';
               tooltip.style.top=(e.clientY+10)+'px';
             }else{ tooltip.style.display='none'; }
@@ -1006,15 +1028,17 @@
       });
     }
     const addUpcoming=document.getElementById('add-upcoming');
+    const upcomingDateInput=document.getElementById('upcoming-date');
+    if(upcomingDateInput){ upcomingDateInput.value=new Date().toISOString().slice(0,16); }
     if(addUpcoming){
       addUpcoming.addEventListener('click',()=>{
         const title=document.getElementById('upcoming-title').value.trim();
-        const date=document.getElementById('upcoming-date').value;
+        const date=upcomingDateInput.value||new Date().toISOString().slice(0,16);
         if(!title) return;
         upcoming.push({title,time:date});
         saveUpcoming(); renderUpcoming();
         document.getElementById('upcoming-title').value='';
-        document.getElementById('upcoming-date').value='';
+        upcomingDateInput.value=new Date().toISOString().slice(0,16);
       });
     }
     if(upcomingList){
@@ -1046,7 +1070,8 @@
       // Mental health chart
       const moodLine = document.getElementById('mood-line');
       const moodDots = document.getElementById('mood-dots');
-      let moodData = [2,3,4,3,5,4,3];
+      // sample data for past 7 days (1-5 scale)
+      let moodData = [3,4,2,5,4,3,4];
       function renderMood(){
         const base=160;
         moodDots.innerHTML='';

--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@
       </div>
       <div class="card" style="margin-top:16px;text-align:center">
         <button class="btn" id="start-survey">🌱 Employee Wellness Survey</button>
-        <p class="mini" style="margin-top:8px"><a href="https://www.youtube.com/watch?v=qs1AxaQTLyE" target="_blank" rel="noopener">Try this office stretch</a></p>
+        <p class="mini" style="margin-top:8px"><a href="https://www.youtube.com/watch?v=EBxV9YDEtAk" target="_blank" rel="noopener">Try this office stretch</a></p>
       </div>
     </section>
 
@@ -784,8 +784,8 @@
             {id:1,title:'Call: Jordan Lee (Acme Co.)',due:todayStr,checked:false},
             {id:2,title:'Call: Priya Shah (Blue Sky Studio)',due:todayStr,checked:false},
             {id:3,title:'Call: Alex Rivera (Zenith Group)',due:todayStr,checked:false},
-            {id:4,title:'Wellness: Stretch for 5 minutes',due:todayStr,checked:false},
-            {id:5,title:'Wellness: Drink water (250 ml)',due:todayStr,checked:false}
+            {id:4,title:'Wellness: Stretch for 5 minutes',due:todayStr,checked:false,link:'https://www.healthline.com/health/deskercise'},
+            {id:5,title:'Wellness: Drink water (250 ml)',due:todayStr,checked:false,link:'https://www.cdc.gov/healthyweight/healthy_eating/water-and-health.htm'}
           ];
         } else {
           dailyTasks = dailyTasks.map(t=>({...t, due: t.due || todayStr}));
@@ -799,7 +799,8 @@
           const div=document.createElement('div');
           div.className='task'+(t.checked?' checked':'');
           div.dataset.id=t.id;
-          div.innerHTML=`<div style="display:flex;align-items:center;gap:6px;"><div class="checkbox ${t.checked?'checked':''}" data-check></div><div contenteditable class="task-title">${t.title}</div></div><div class="mini">Due: <input type="date" class="task-due" value="${t.due||todayStr}" /></div>`;
+          const linkHTML = t.link ? `<div class="mini"><a href="${t.link}" target="_blank">Learn more</a></div>` : '';
+          div.innerHTML=`<div style="display:flex;align-items:center;gap:6px;"><div class="checkbox ${t.checked?'checked':''}" data-check></div><div contenteditable class="task-title">${t.title}</div></div><div class="mini">Due: <input type="date" class="task-due" value="${t.due||todayStr}" /></div>${linkHTML}`;
           dailyList.appendChild(div);
         });
       }
@@ -912,6 +913,8 @@
       const tooltip = document.createElement('div');
       tooltip.id='chart-tooltip';
       document.body.appendChild(tooltip);
+      // Seed mental health data so charts have values on load
+      let moodData = [3,4,2,5,4,3,4];
       function renderCharts(){
         const overdueCtx = document.getElementById('overdue-chart')?.getContext('2d');
         const completedCtx = document.getElementById('completed-chart')?.getContext('2d');
@@ -934,7 +937,8 @@
         barData[id]=[];
         data.forEach((v,i)=>{
           const x=(i*2+1)*bw;
-          const barH=v*20;
+          const mult = id==='workload-chart'?10:20;
+          const barH=v*mult;
           const y=h-barH;
           ctx.fillStyle=color;
           ctx.fillRect(x,y,bw,barH);
@@ -963,8 +967,8 @@
       function renderWorkflow(){
         const ctx = document.getElementById('workflow-chart')?.getContext('2d');
         if(!ctx) return;
-        const labels = tasks.map(t=>t.title);
-        const data = tasks.map(t=> t.status==='done'?5 : t.status==='progress'?2.5 : 0);
+        const labels = ['Research','Design','Development','Testing','Launch'];
+        const data = [1,2,3,4,5];
         drawBars(ctx, data, '#6366f1', labels);
       }
     loadTasks();
@@ -1035,7 +1039,7 @@
         const title=document.getElementById('upcoming-title').value.trim();
         const date=upcomingDateInput.value||new Date().toISOString().slice(0,16);
         if(!title) return;
-        upcoming.push({title,time:date});
+        upcoming.unshift({title,time:date});
         saveUpcoming(); renderUpcoming();
         document.getElementById('upcoming-title').value='';
         upcomingDateInput.value=new Date().toISOString().slice(0,16);
@@ -1071,7 +1075,6 @@
       const moodLine = document.getElementById('mood-line');
       const moodDots = document.getElementById('mood-dots');
       // sample data for past 7 days (1-5 scale)
-      let moodData = [3,4,2,5,4,3,4];
       function renderMood(){
         const base=160;
         moodDots.innerHTML='';
@@ -1260,7 +1263,7 @@
       }
       if(modalClose){ modalClose.addEventListener('click', saveTaskModal); }
     function openTaskDetails(taskEl){
-      let title='', due='', source='', id='';
+      let title='', due='', source='', id='', article='';
       if(taskEl.dataset.id){
         const t = tasks.find(x=>x.id===Number(taskEl.dataset.id));
         if(t){ title=t.title; due=t.due||''; source='kanban'; id=t.id; }
@@ -1270,7 +1273,7 @@
         title = u.title; due = u.time; source='upcoming'; id=idx;
       }else if(taskEl.closest('#page-daily')){
         const d = dailyTasks.find(x=>x.id===Number(taskEl.dataset.id));
-        if(d){ title=d.title; due=d.due||''; source='daily'; id=d.id; }
+        if(d){ title=d.title; due=d.due||''; source='daily'; id=d.id; article=d.link; }
       }else if(taskEl.closest('#pipeline')){
         title = taskEl.textContent.trim();
         due = taskEl.parentElement.dataset.stage || '';
@@ -1281,11 +1284,14 @@
         modalDue.value = due ? (due.includes('T')?due:due+'T00:00') : '';
         modalNote.value = taskNotes[title] || '';
         const contact = findCRMContactFromTitle(title);
+        let html='';
         if(contact){
-          modalContact.innerHTML = `<a href="#page-crm" class="crm-link" data-target="${contact.id}">View contact: ${contact.name}</a>`;
-        }else{
-          modalContact.textContent='';
+          html += `<a href="#page-crm" class="crm-link" data-target="${contact.id}">View contact: ${contact.name}</a>`;
         }
+        if(article){
+          html += `${html?'<br/>':''}<a href="${article}" target="_blank">Wellness article</a>`;
+        }
+        modalContact.innerHTML = html;
         taskModal.dataset.key = title;
         taskModal.dataset.source = source;
         taskModal.dataset.id = id;

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
     .grid{display:grid;gap:16px}
     .grid-3{grid-template-columns:repeat(3,minmax(0,1fr))}
     .grid-2{grid-template-columns:repeat(2,minmax(0,1fr))}
+    .crm-grid{grid-template-columns:3fr 1fr}
     .card{background:var(--card);border:1px solid var(--border);border-radius:14px;box-shadow:0 10px 24px rgba(17,12,34,.06);padding:16px}
     .card h3{margin:0 0 10px 0}
     .btn{background:var(--purple);color:#fff;border:none;border-radius:10px;padding:10px 14px;cursor:pointer}
@@ -50,14 +51,17 @@
     .table td{background:#fff;border:1px solid var(--border);padding:10px 8px}
     .table td:first-child{border-radius:10px 0 0 10px}
     .table td:last-child{border-radius:0 10px 10px 0}
+    .table td[data-stage]{min-width:140px}
+    .stage-select{min-width:140px}
     .pill{display:inline-flex;align-items:center;gap:6px;padding:4px 8px;border-radius:999px;font-size:12px;border:1px solid var(--border);background:var(--purple-100);color:var(--purple-600)}
-    .kanban{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
-    .column{background:var(--bg-alt);border:1px dashed var(--border);border-radius:12px;padding:10px}
+    .kanban{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;overflow-x:auto}
+    .column{background:var(--bg-alt);border:1px dashed var(--border);border-radius:12px;padding:10px;min-width:300px}
     .column h4{margin:0 0 8px 0}
     .task{background:#fff;border:1px solid var(--border);border-radius:12px;padding:10px;margin-bottom:8px}
     .subtask{display:flex;align-items:center;gap:8px;margin:6px 0}
     .assistant{background:linear-gradient(180deg,#efe8ff,#fff);border:1px solid var(--border);border-radius:14px;padding:12px}
-    .prompt{background:#fff;border:1px solid var(--border);border-radius:10px;padding:10px;margin:8px 0}
+    .prompt{display:block;background:#fff;border:1px solid var(--border);border-radius:10px;padding:10px;margin:8px 0}
+    .prompt:hover{background:var(--purple-100)}
     .kpi{display:flex;align-items:center;justify-content:space-between}
     .mini{font-size:12px;color:var(--muted)}
     .cta-grid{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:14px}
@@ -67,8 +71,13 @@
     .linkrow{display:flex;gap:10px;flex-wrap:wrap}
     .muted{color:var(--muted)}
     .chart{width:100%;height:180px;background:conic-gradient(from 180deg at 50% 50%, #e9e5f7, #efe8ff);border-radius:12px;border:1px solid var(--border);display:grid;place-items:center}
-    .checkbox{width:18px;height:18px;border-radius:6px;border:1px solid var(--border);display:inline-grid;place-items:center}
+    .checkbox{width:18px;height:18px;border-radius:6px;border:1px solid var(--border);display:inline-grid;place-items:center;cursor:pointer}
+    .checkbox.checked{background:var(--purple);color:#fff}
+    .checkbox.checked::before{content:'✓'}
+    .task.checked .task-title{text-decoration:line-through;color:var(--muted)}
     .notice{background:#f6f3ff;border:1px solid var(--border);padding:10px;border-radius:10px}
+    .add-task-row{display:flex;gap:6px;margin-top:8px}
+    #chart-tooltip{position:fixed;pointer-events:none;background:#fff;border:1px solid var(--border);padding:4px 8px;border-radius:6px;font-size:12px;box-shadow:0 2px 4px rgba(17,12,34,.08);display:none}
     footer{padding:30px 20px;color:var(--muted);text-align:center}
   </style>
 </head>
@@ -111,75 +120,127 @@
 
     <!-- CRM SNAPSHOT -->
     <section id="page-crm" class="page hidden">
-      <div class="grid grid-2">
-        <div class="card">
-          <h3>Clients <span class="pill">Editable</span></h3>
-          <table class="table" id="client-table">
-            <thead>
-              <tr><th>Name</th><th>Company</th><th>Email</th><th>Phone</th><th>Stage</th><th>Owner</th></tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td contenteditable>Alex Rivera</td>
-                <td contenteditable>Zenith Group</td>
-                <td contenteditable>alex@zenithgrp.com</td>
-                <td contenteditable>(404) 555‑0101</td>
-                <td contenteditable data-stage>Lead</td>
-                <td contenteditable>Nate</td>
-              </tr>
-              <tr>
-                <td contenteditable>Priya Shah</td>
-                <td contenteditable>Blue Sky Studio</td>
-                <td contenteditable>priya@blueskystudio.io</td>
-                <td contenteditable>(470) 555‑0199</td>
-                <td contenteditable data-stage>Proposal</td>
-                <td contenteditable>Nate</td>
-              </tr>
-              <tr id="crm-acme">
-                <td contenteditable>Jordan Lee</td>
-                <td contenteditable>Acme Co.</td>
-                <td contenteditable>jordan@acmeco.com</td>
-                <td contenteditable>(678) 555‑0147</td>
-                <td contenteditable data-stage>Won</td>
-                <td contenteditable>Nate</td>
-              </tr>
-            </tbody>
-          </table>
+      <div class="linkrow" id="crm-tabs" style="margin-bottom:12px">
+        <button class="btn crm-tab active" data-target="crm-clients">Clients</button>
+        <button class="btn crm-tab" data-target="crm-companies">Companies</button>
+      </div>
+      <div id="crm-clients">
+        <div class="grid grid-2 crm-grid">
+          <div class="card">
+            <h3>Clients <span class="pill">Editable</span></h3>
+            <input class="input" id="client-search" placeholder="Search clients" style="margin-bottom:8px" />
+            <table class="table" id="client-table">
+              <thead>
+                <tr><th>Name</th><th>Company</th><th>Email</th><th>Phone</th><th>Stage</th><th>Owner</th></tr>
+              </thead>
+              <tbody>
+                <tr id="crm-alex" data-address="123 Peachtree Rd, Atlanta, GA" data-notes="">
+                  <td contenteditable class="client-name">Alex Rivera</td>
+                  <td contenteditable>Zenith Group</td>
+                  <td contenteditable>alex@zenithgrp.com</td>
+                  <td contenteditable>(404) 555‑0101</td>
+                  <td data-stage><select class="input stage-select"><option selected>Lead</option><option>Discovery</option><option>Proposal</option><option>Negotiation</option><option>Won</option></select></td>
+                  <td contenteditable>Nate</td>
+                </tr>
+                <tr id="crm-priya" data-address="500 Midtown Ave, Atlanta, GA" data-notes="">
+                  <td contenteditable class="client-name">Priya Shah</td>
+                  <td contenteditable>Blue Sky Studio</td>
+                  <td contenteditable>priya@blueskystudio.io</td>
+                  <td contenteditable>(470) 555‑0199</td>
+                  <td data-stage><select class="input stage-select"><option>Lead</option><option>Discovery</option><option selected>Proposal</option><option>Negotiation</option><option>Won</option></select></td>
+                  <td contenteditable>Nate</td>
+                </tr>
+                <tr id="crm-acme" data-address="42 Industrial Way, Atlanta, GA" data-notes="">
+                  <td contenteditable class="client-name">Jordan Lee</td>
+                  <td contenteditable>Acme Co.</td>
+                  <td contenteditable>jordan@acmeco.com</td>
+                  <td contenteditable>(678) 555‑0147</td>
+                  <td data-stage><select class="input stage-select"><option>Lead</option><option>Discovery</option><option>Proposal</option><option>Negotiation</option><option selected>Won</option></select></td>
+                  <td contenteditable>Nate</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="card">
+            <h3>Add New Client</h3>
+            <div class="grid">
+              <input class="input" id="new-name" placeholder="Full name" />
+              <input class="input" id="new-company" placeholder="Company" />
+              <input class="input" id="new-email" placeholder="Email" />
+              <input class="input" id="new-phone" placeholder="Phone" />
+              <select id="new-stage" class="input">
+                <option>Lead</option><option>Discovery</option><option>Proposal</option><option>Negotiation</option><option>Won</option>
+              </select>
+              <input class="input" id="new-owner" placeholder="Owner" value="Nate" />
+              <div class="linkrow">
+                <button class="btn" id="add-client">Add Client</button>
+                <button class="btn secondary" id="save-crm">Save Changes (Local)</button>
+                <button class="btn link" data-nav="#page-cover">Back to Cover</button>
+              </div>
+            </div>
+            <p class="mini muted" style="margin-top:8px">Edits are inline. “Save Changes” stores a local copy in your browser for demo purposes.</p>
+          </div>
         </div>
-        <div class="card">
-          <h3>Add New Client</h3>
-          <div class="grid">
-            <input class="input" id="new-name" placeholder="Full name" />
-            <input class="input" id="new-company" placeholder="Company" />
-            <input class="input" id="new-email" placeholder="Email" />
-            <input class="input" id="new-phone" placeholder="Phone" />
-            <select id="new-stage" class="input">
-              <option>Lead</option><option>Discovery</option><option>Proposal</option><option>Negotiation</option><option>Won</option>
-            </select>
-            <input class="input" id="new-owner" placeholder="Owner" value="Nate" />
-            <div class="linkrow">
-              <button class="btn" id="add-client">Add Client</button>
-              <button class="btn secondary" id="save-crm">Save Changes (Local)</button>
-              <button class="btn link" data-nav="#page-cover">Back to Cover</button>
+      </div>
+      <div id="crm-companies" class="hidden">
+        <div class="grid grid-2 crm-grid">
+          <div class="card">
+            <h3>Companies <span class="pill">Editable</span></h3>
+            <input class="input" id="company-search" placeholder="Search companies" style="margin-bottom:8px" />
+            <table class="table" id="company-table">
+              <thead>
+                <tr><th>Company</th><th>Industry</th><th>Website</th><th>Stage</th><th>Owner</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td contenteditable>Zenith Group</td>
+                  <td contenteditable>Finance</td>
+                  <td contenteditable>zenithgrp.com</td>
+                  <td data-stage><select class="input stage-select"><option>Lead</option><option>Discovery</option><option selected>Proposal</option><option>Negotiation</option><option>Won</option></select></td>
+                  <td contenteditable>Nate</td>
+                </tr>
+                <tr>
+                  <td contenteditable>Blue Sky Studio</td>
+                  <td contenteditable>Design</td>
+                  <td contenteditable>blueskystudio.io</td>
+                  <td data-stage><select class="input stage-select"><option selected>Lead</option><option>Discovery</option><option>Proposal</option><option>Negotiation</option><option>Won</option></select></td>
+                  <td contenteditable>Nate</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="card">
+            <h3>Add New Company</h3>
+            <div class="grid">
+              <input class="input" id="new-comp-name" placeholder="Company name" />
+              <input class="input" id="new-comp-industry" placeholder="Industry" />
+              <input class="input" id="new-comp-website" placeholder="Website" />
+              <select id="new-comp-stage" class="input">
+                <option>Lead</option><option>Discovery</option><option>Proposal</option><option>Negotiation</option><option>Won</option>
+              </select>
+              <input class="input" id="new-comp-owner" placeholder="Owner" value="Nate" />
+              <div class="linkrow">
+                <button class="btn" id="add-company">Add Company</button>
+                <button class="btn secondary" id="save-companies">Save Changes (Local)</button>
+              </div>
             </div>
           </div>
-          <p class="mini muted" style="margin-top:8px">Edits are inline. “Save Changes” stores a local copy in your browser for demo purposes.</p>
         </div>
       </div>
       <div class="card" style="margin-top:16px">
         <h3>Pipeline <span class="badge">Lead → Proposal → Won</span></h3>
         <div class="grid grid-3" id="pipeline">
-          <div class="column">
+          <div class="column" data-stage="Lead">
             <h4>Lead</h4>
-            <div class="task">Alex Rivera – Zenith Group</div>
+            <div class="task" draggable="true">Alex Rivera – Zenith Group</div>
           </div>
-          <div class="column">
+          <div class="column" data-stage="Proposal">
             <h4>Proposal</h4>
-            <div class="task">Priya Shah – Blue Sky Studio</div>
+            <div class="task" draggable="true">Priya Shah – Blue Sky Studio</div>
           </div>
-          <div class="column">
+          <div class="column" data-stage="Won">
             <h4>Won</h4>
-            <div class="task">Jordan Lee – Acme Co.</div>
+            <div class="task" draggable="true">Jordan Lee – Acme Co.</div>
           </div>
         </div>
       </div>
@@ -190,52 +251,62 @@
       <div class="grid grid-2">
         <div class="card">
           <h3>Project Tasks (Kanban)</h3>
+          <div class="linkrow" style="margin:8px 0">
+            <select id="task-template" class="input" style="max-width:220px">
+              <option value="">Add from template...</option>
+              <option>Follow up after proposal</option>
+              <option>Prepare onboarding packet</option>
+              <option>Weekly status update</option>
+            </select>
+            <button class="btn" id="add-template">Add</button>
+          </div>
           <div class="kanban">
-            <div class="column">
+            <div class="column" data-status="todo">
               <h4>To Do</h4>
-              <div class="task" id="task-default">
-                <strong>Launch Onboarding Flow</strong>
-                <div class="subtask"><span class="checkbox">✓</span> Create welcome email draft</div>
-                <div class="subtask"><span class="checkbox"></span> Build onboarding checklist</div>
-                <div class="subtask"><span class="checkbox"></span> QA test with sample client</div>
-                <div class="mini muted">Owner: Nate • Due: Sep 5</div>
+              <div id="todo-list"></div>
+              <div class="add-task-row">
+                <input class="input" id="todo-new-title" placeholder="Task title" style="flex:2" />
+                <input type="date" class="input" id="todo-new-due" style="flex:1" />
+                <button class="btn add-task" data-status="todo">Add</button>
               </div>
             </div>
-            <div class="column">
+            <div class="column" data-status="progress">
               <h4>In Progress</h4>
-              <div class="task">
-                <strong>Proposal for Blue Sky Studio</strong>
-                <div class="subtask"><span class="checkbox">✓</span> Gather scope & assets</div>
-                <div class="subtask"><span class="checkbox"></span> Draft proposal in Docs</div>
-                <div class="subtask"><span class="checkbox"></span> Send for review</div>
-                <div class="mini muted">Owner: Nate • Due: Aug 28</div>
+              <div id="progress-list"></div>
+              <div class="add-task-row">
+                <input class="input" id="progress-new-title" placeholder="Task title" style="flex:2" />
+                <input type="date" class="input" id="progress-new-due" style="flex:1" />
+                <button class="btn add-task" data-status="progress">Add</button>
               </div>
             </div>
-            <div class="column">
+            <div class="column" data-status="done">
               <h4>Done</h4>
-              <div class="task">
-                <strong>Kickoff – Acme Co.</strong>
-                <div class="subtask"><span class="checkbox">✓</span> Schedule meeting</div>
-                <div class="subtask"><span class="checkbox">✓</span> Share agenda</div>
-                <div class="subtask"><span class="checkbox">✓</span> Confirm attendees</div>
-                <div class="mini muted">Owner: Nate • Completed</div>
+              <div id="done-list"></div>
+              <div class="add-task-row">
+                <input class="input" id="done-new-title" placeholder="Task title" style="flex:2" />
+                <input type="date" class="input" id="done-new-due" style="flex:1" />
+                <button class="btn add-task" data-status="done">Add</button>
               </div>
             </div>
           </div>
         </div>
         <div class="card assistant">
           <h3>AI Assistant (Prompts)</h3>
-          <div class="prompt">“Prioritize my tasks for today based on due dates and client impact.”</div>
-          <div class="prompt">“Draft a follow‑up email to <em>Priya Shah at Blue Sky Studio</em> about the proposal.”</div>
-          <div class="prompt">“Summarize yesterday’s activity for <em>Jordan Lee (Acme Co.)</em> and suggest next steps.”</div>
-          <div class="prompt">“Generate 3 wellness nudges for a busy day with back‑to‑back calls.”</div>
-          <div class="prompt">“Create a checklist to launch the onboarding flow this week.”</div>
+          <a class="prompt" target="_blank" rel="noopener" href="https://chat.openai.com/?q=Prioritize%20my%20tasks%20for%20today%20based%20on%20due%20dates%20and%20client%20impact.">“Prioritize my tasks for today based on due dates and client impact.”</a>
+          <a class="prompt" target="_blank" rel="noopener" href="https://chat.openai.com/?q=Draft%20a%20follow-up%20email%20to%20Priya%20Shah%20at%20Blue%20Sky%20Studio%20about%20the%20proposal.">“Draft a follow‑up email to <em>Priya Shah at Blue Sky Studio</em> about the proposal.”</a>
+          <a class="prompt" target="_blank" rel="noopener" href="https://chat.openai.com/?q=Summarize%20yesterday%E2%80%99s%20activity%20for%20Jordan%20Lee%20(Acme%20Co.)%20and%20suggest%20next%20steps.">“Summarize yesterday’s activity for <em>Jordan Lee (Acme Co.)</em> and suggest next steps.”</a>
+          <a class="prompt" target="_blank" rel="noopener" href="https://chat.openai.com/?q=Generate%203%20wellness%20nudges%20for%20a%20busy%20day%20with%20back-to-back%20calls.">“Generate 3 wellness nudges for a busy day with back‑to‑back calls.”</a>
+          <a class="prompt" target="_blank" rel="noopener" href="https://chat.openai.com/?q=Create%20a%20checklist%20to%20launch%20the%20onboarding%20flow%20this%20week.">“Create a checklist to launch the onboarding flow this week.”</a>
           <div class="notice mini">Non‑functional demo: prompts are static for prototype purposes.</div>
           <div class="linkrow" style="margin-top:8px">
             <button class="btn" data-nav="#page-crm">View CRM</button>
             <button class="btn secondary" data-nav="#page-daily">Go to Daily Tasks</button>
           </div>
         </div>
+      </div>
+      <div class="card" style="margin-top:16px">
+        <h3>Workflow Progress</h3>
+        <canvas id="workflow-chart" width="640" height="180" class="chart"></canvas>
       </div>
     </section>
 
@@ -244,39 +315,21 @@
       <div class="grid grid-2">
         <div class="card">
           <h3>Today’s Top Tasks</h3>
-          <div class="task">
-            <strong>Call: Jordan Lee (Acme Co.)</strong>
-            <div class="mini"><a href="#page-crm" class="crm-link" data-target="crm-acme">Open in CRM</a> • (678) 555‑0147</div>
-          </div>
-          <div class="task">
-            <strong>Call: Priya Shah (Blue Sky Studio)</strong>
-            <div class="mini">(470) 555‑0199</div>
-          </div>
-          <div class="task">
-            <strong>Call: Alex Rivera (Zenith Group)</strong>
-            <div class="mini">(404) 555‑0101</div>
-          </div>
-          <div class="task">
-            <strong>Wellness: Stretch for 5 minutes</strong>
-            <div class="mini muted">Nudge repeats every 90 minutes</div>
-          </div>
-          <div class="task">
-            <strong>Wellness: Drink water (250 ml)</strong>
-            <div class="mini muted">Track 8 servings daily</div>
+          <div id="daily-list"></div>
+          <div class="add-task-row">
+            <input class="input" id="daily-new-title" placeholder="New task" style="flex:1" />
+            <input type="date" class="input" id="daily-new-due" style="flex:0 0 130px" />
+            <button class="btn" id="daily-add">Add</button>
           </div>
           <button class="btn" id="done-day">Mark Done for the Day</button>
         </div>
         <div class="card">
           <h3>Mental Health Trend</h3>
           <div class="mini muted">Self‑reported 1–5 scale • Past 7 days</div>
-          <svg viewBox="0 0 320 180" class="chart" aria-label="Mental health chart">
-            <polyline points="10,140 55,120 100,100 145,110 190,90 235,80 280,70" fill="none" stroke="#6b46c1" stroke-width="3" />
-            <g fill="#6b46c1">
-              <circle cx="10" cy="140" r="4"/><circle cx="55" cy="120" r="4"/><circle cx="100" cy="100" r="4"/>
-              <circle cx="145" cy="110" r="4"/><circle cx="190" cy="90" r="4"/><circle cx="235" cy="80" r="4"/>
-              <circle cx="280" cy="70" r="4"/>
-            </g>
-          </svg>
+            <svg viewBox="0 0 320 180" class="chart" id="mood-chart" aria-label="Mental health chart">
+              <polyline id="mood-line" fill="none" stroke="#6b46c1" stroke-width="3"></polyline>
+              <g id="mood-dots" fill="#6b46c1"></g>
+            </svg>
           <div class="grid" style="margin-top:10px">
             <select id="mood-today" class="input">
               <option value="5">Today’s mood: 5 (Great)</option>
@@ -290,31 +343,44 @@
           <p class="mini muted">This is a visual demo; logging won’t persist beyond this session.</p>
         </div>
       </div>
+      <div class="card" style="margin-top:16px;text-align:center">
+        <button class="btn" id="start-survey">🌱 Employee Wellness Survey</button>
+        <p class="mini" style="margin-top:8px"><a href="https://www.youtube.com/watch?v=qs1AxaQTLyE" target="_blank" rel="noopener">Try this office stretch</a></p>
+      </div>
     </section>
 
     <!-- INSIGHTS CHARTS -->
     <section id="page-insights" class="page hidden">
-      <div class="grid grid-3">
+      <div class="grid grid-2">
         <div class="card">
           <h3>Overdue Tasks</h3>
-          <div class="chart">Line trend ↓</div>
-          <div class="kpi"><span class="muted">Last 30 days</span><strong>‑18%</strong></div>
+          <div id="overdue-count" class="mini" style="color:var(--danger);margin-bottom:8px"></div>
+          <canvas id="overdue-chart" width="320" height="180" class="chart"></canvas>
+          <ul id="overdue-list" class="mini"></ul>
         </div>
         <div class="card">
-          <h3>Automation Adoption</h3>
-          <div class="chart">Gauge 68%</div>
-          <div class="kpi"><span class="muted">Users automated</span><strong>68%</strong></div>
+          <h3>Completed Tasks</h3>
+          <div id="completed-count" class="mini" style="color:var(--success);margin-bottom:8px"></div>
+          <canvas id="completed-chart" width="320" height="180" class="chart"></canvas>
+          <ul id="completed-list" class="mini"></ul>
         </div>
-        <div class="card">
-          <h3>Daily Completion Rate</h3>
-          <div class="chart">Bars</div>
-          <div class="kpi"><span class="muted">Avg last week</span><strong>80%</strong></div>
-        </div>
+      </div>
+      <div class="card" style="margin-top:16px">
+        <h3>Workload Balance</h3>
+        <canvas id="workload-chart" width="320" height="120" class="chart"></canvas>
+        <ul id="workload-metrics" class="mini"></ul>
+      </div>
+      <div class="card" style="margin-top:16px">
+        <h3>Mental Health Overview</h3>
+        <canvas id="personal-mood-chart" width="320" height="120" class="chart"></canvas>
+        <div class="mini muted">Your last 7 logs</div>
+        <canvas id="team-mood-chart" width="320" height="120" class="chart" style="margin-top:12px"></canvas>
+        <div class="mini muted">Team average mood</div>
       </div>
     </section>
 
     <!-- CALENDAR -->
-    <section id="page-calendar" class="page hidden">
+      <section id="page-calendar" class="page hidden">
       <div class="grid grid-2">
         <div class="card">
           <h3>Calendar</h3>
@@ -324,9 +390,62 @@
         </div>
         <div class="card">
           <h3>Upcoming (Demo)</h3>
-          <div class="task"><strong>Client Call – Acme Co.</strong><div class="mini">Sep 2, 10:00–10:30</div></div>
-          <div class="task"><strong>Proposal Review – Blue Sky</strong><div class="mini">Sep 3, 14:00–14:30</div></div>
-          <div class="task"><strong>Onboarding Session</strong><div class="mini">Sep 5, 09:00–09:45</div></div>
+          <div id="upcoming-list"></div>
+          <div class="add-task-row">
+            <input class="input" id="upcoming-title" placeholder="Event title" style="flex:2" />
+            <input type="datetime-local" class="input" id="upcoming-date" style="flex:1" />
+            <button class="btn" id="add-upcoming">Add</button>
+          </div>
+        </div>
+      </div>
+      </section>
+
+      <!-- WELLNESS SURVEY MODAL -->
+      <section id="survey-modal" class="hidden" aria-hidden="true">
+        <div style="position:fixed;inset:0;background:rgba(31,26,51,.66);display:grid;place-items:center;z-index:1000">
+          <div class="card" style="max-width:480px">
+            <h3 id="survey-title">🌱 Employee Mental Wellness & Productivity Survey</h3>
+            <p id="survey-question"></p>
+            <div id="survey-options" style="margin:8px 0"></div>
+            <div id="survey-feedback" class="mini" style="min-height:40px"></div>
+            <div class="linkrow" style="margin-top:12px;justify-content:flex-end">
+              <button class="btn secondary" id="survey-next">Next</button>
+              <button class="btn link" id="survey-close">Close</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- TASK DETAIL MODAL -->
+      <section id="task-modal" class="hidden" aria-hidden="true">
+      <div style="position:fixed;inset:0;background:rgba(31,26,51,.66);display:grid;place-items:center;z-index:1000">
+        <div class="card" style="max-width:360px;text-align:center">
+          <h3 id="modal-title"></h3>
+          <p class="mini" style="margin-bottom:4px">Due:</p>
+          <input type="datetime-local" id="modal-due" class="input" style="margin-bottom:8px" />
+          <textarea id="modal-note" class="input" placeholder="Add notes" style="margin:8px 0"></textarea>
+          <div id="modal-contact" class="mini" style="margin-bottom:8px"></div>
+          <button class="btn secondary" id="modal-close">Close</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- CLIENT DETAIL MODAL -->
+    <section id="client-modal" class="hidden" aria-hidden="true">
+      <div style="position:fixed;inset:0;background:rgba(31,26,51,.66);display:grid;place-items:center;z-index:1000">
+        <div class="card" style="max-width:400px">
+          <h3 id="client-name"></h3>
+          <p class="mini" id="client-company"></p>
+          <p class="mini" id="client-email"></p>
+          <p class="mini" id="client-phone"></p>
+          <p class="mini">Stage: <span id="client-stage"></span> • Owner: <span id="client-owner"></span></p>
+          <p class="mini">Address:</p>
+          <div id="client-address" contenteditable class="input" style="margin-bottom:6px"></div>
+          <p class="mini"><a id="client-map" href="#" target="_blank">View on map</a></p>
+          <textarea id="client-notes" class="input" placeholder="Notes" style="margin-top:6px"></textarea>
+          <div class="linkrow" style="margin-top:10px;justify-content:center">
+            <button class="btn secondary" id="client-close">Close</button>
+          </div>
         </div>
       </div>
     </section>
@@ -388,44 +507,782 @@
     // On load
     showPage(location.hash || '#page-cover');
 
-    // CRM: Add + Save (localStorage)
-    const addBtn = document.getElementById('add-client');
-    const saveBtn = document.getElementById('save-crm');
-    const table = document.getElementById('client-table').querySelector('tbody');
+    // CRM tabs
+    document.querySelectorAll('.crm-tab').forEach(btn=>{
+      btn.addEventListener('click',()=>{
+        document.querySelectorAll('.crm-tab').forEach(b=>b.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById('crm-clients').classList.toggle('hidden', btn.dataset.target!=='crm-clients');
+        document.getElementById('crm-companies').classList.toggle('hidden', btn.dataset.target!=='crm-companies');
+      });
+    });
+
+    const stageOptions = ['Lead','Discovery','Proposal','Negotiation','Won'];
+    function stageDropdown(val){
+      return `<select class="input stage-select">${stageOptions.map(o=>`<option ${o===val?'selected':''}>${o}</option>`).join('')}</select>`;
+    }
+
+    const pipelineBoard = document.getElementById('pipeline');
+    function addToPipeline(name, company, stage){
+      if(!pipelineBoard) return;
+      const col=[...pipelineBoard.querySelectorAll('.column')].find(c=>c.dataset.stage===stage);
+      if(col){
+        const div=document.createElement('div');
+        div.className='task';
+        div.textContent=`${name} – ${company}`;
+        div.draggable=true;
+        div.addEventListener('dragstart',()=> draggedPerson=div);
+        col.appendChild(div);
+      }
+    }
+
+    // Clients table
+    const addClientBtn = document.getElementById('add-client');
+    const saveClientBtn = document.getElementById('save-crm');
+    const clientTable = document.getElementById('client-table').querySelector('tbody');
+    const clientSearch = document.getElementById('client-search');
     function getVal(id){ return document.getElementById(id).value.trim(); }
-    if(addBtn){
-      addBtn.addEventListener('click', ()=>{
+    if(addClientBtn){
+      addClientBtn.addEventListener('click', ()=>{
         const name=getVal('new-name'); const comp=getVal('new-company'); const email=getVal('new-email'); const phone=getVal('new-phone'); const stage=getVal('new-stage'); const owner=getVal('new-owner');
         if(!name||!comp){ alert('Name and Company are required.'); return; }
         const tr=document.createElement('tr');
-        tr.innerHTML=`<td contenteditable>${name}</td><td contenteditable>${comp}</td><td contenteditable>${email}</td><td contenteditable>${phone}</td><td contenteditable data-stage>${stage}</td><td contenteditable>${owner}</td>`;
-        table.appendChild(tr);
+        tr.innerHTML=`<td contenteditable>${name}</td><td contenteditable>${comp}</td><td contenteditable>${email}</td><td contenteditable>${phone}</td><td data-stage>${stageDropdown(stage)}</td><td contenteditable>${owner}</td>`;
+        clientTable.appendChild(tr);
+        addToPipeline(name, comp, stage);
         ['new-name','new-company','new-email','new-phone','new-owner'].forEach(id=>document.getElementById(id).value='');
       });
     }
-    function serializeCRM(){
-      return [...table.querySelectorAll('tr')].map(tr=>[...tr.children].map(td=>td.textContent));
+    function serializeClients(){
+      return [...clientTable.querySelectorAll('tr')].map(tr=>[...tr.children].map(td=>{
+        const sel=td.querySelector('select');
+        return sel? sel.value : td.textContent;
+      }));
     }
-    if(saveBtn){
-      saveBtn.addEventListener('click', ()=>{
-        const data = serializeCRM();
+    if(clientSearch){
+      clientSearch.addEventListener('input', ()=>{
+        const q = clientSearch.value.toLowerCase();
+        [...clientTable.querySelectorAll('tr')].forEach(tr=>{
+          const match = [...tr.children].some(td=>(td.textContent||td.querySelector('select')?.value||'').toLowerCase().includes(q));
+          tr.style.display = match ? '' : 'none';
+        });
+      });
+    }
+    if(saveClientBtn){
+      saveClientBtn.addEventListener('click', ()=>{
+        const data = serializeClients();
         localStorage.setItem('crm-demo', JSON.stringify(data));
         alert('Saved locally for demo.');
       });
-      // Load on init if present
       const saved = localStorage.getItem('crm-demo');
       if(saved){
         try{
           const rows = JSON.parse(saved);
-          table.innerHTML='';
+          clientTable.innerHTML='';
           rows.forEach(cols=>{
             const tr=document.createElement('tr');
-            tr.innerHTML = cols.map((v,i)=>`<td contenteditable ${i===4? 'data-stage':''}>${v}</td>`).join('');
-            table.appendChild(tr);
-          })
+            tr.innerHTML = cols.map((v,i)=> i===4? `<td data-stage>${stageDropdown(v)}</td>` : `<td contenteditable>${v}</td>`).join('');
+            clientTable.appendChild(tr);
+          });
         }catch(err){ console.warn('Failed to parse saved CRM data', err); }
       }
     }
+
+    // Companies table
+    const addCompanyBtn = document.getElementById('add-company');
+    const saveCompaniesBtn = document.getElementById('save-companies');
+    const companyTable = document.getElementById('company-table').querySelector('tbody');
+    const companySearch = document.getElementById('company-search');
+    if(addCompanyBtn){
+      addCompanyBtn.addEventListener('click',()=>{
+        const name=getVal('new-comp-name'); const industry=getVal('new-comp-industry'); const site=getVal('new-comp-website'); const stage=getVal('new-comp-stage'); const owner=getVal('new-comp-owner');
+        if(!name){ alert('Company name required'); return; }
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td contenteditable>${name}</td><td contenteditable>${industry}</td><td contenteditable>${site}</td><td data-stage>${stageDropdown(stage)}</td><td contenteditable>${owner}</td>`;
+        companyTable.appendChild(tr);
+        ['new-comp-name','new-comp-industry','new-comp-website','new-comp-owner'].forEach(id=>document.getElementById(id).value='');
+      });
+    }
+    function serializeCompanies(){
+      return [...companyTable.querySelectorAll('tr')].map(tr=>[...tr.children].map(td=>{
+        const sel=td.querySelector('select');
+        return sel? sel.value : td.textContent;
+      }));
+    }
+    if(companySearch){
+      companySearch.addEventListener('input',()=>{
+        const q = companySearch.value.toLowerCase();
+        [...companyTable.querySelectorAll('tr')].forEach(tr=>{
+          const match = [...tr.children].some(td=>(td.textContent||td.querySelector('select')?.value||'').toLowerCase().includes(q));
+          tr.style.display = match ? '' : 'none';
+        });
+      });
+    }
+    if(saveCompaniesBtn){
+      saveCompaniesBtn.addEventListener('click',()=>{
+        localStorage.setItem('companies-demo', JSON.stringify(serializeCompanies()));
+        alert('Saved locally for demo.');
+      });
+      const savedCompanies = localStorage.getItem('companies-demo');
+      if(savedCompanies){
+        try{
+          const rows = JSON.parse(savedCompanies);
+          companyTable.innerHTML='';
+          rows.forEach(cols=>{
+            const tr=document.createElement('tr');
+            tr.innerHTML = cols.map((v,i)=> i===3? `<td data-stage>${stageDropdown(v)}</td>` : `<td contenteditable>${v}</td>`).join('');
+            companyTable.appendChild(tr);
+          });
+        }catch(err){ console.warn('Failed to parse saved companies data', err); }
+      }
+    }
+
+      // CRM detail modal
+      const clientModal = document.getElementById('client-modal');
+      const clientClose = document.getElementById('client-close');
+      const clientNameEl = document.getElementById('client-name');
+      const clientCompany = document.getElementById('client-company');
+      const clientEmail = document.getElementById('client-email');
+      const clientPhone = document.getElementById('client-phone');
+      const clientStage = document.getElementById('client-stage');
+      const clientOwner = document.getElementById('client-owner');
+      const clientAddress = document.getElementById('client-address');
+      const clientNotes = document.getElementById('client-notes');
+      const clientMap = document.getElementById('client-map');
+      let currentClientRow = null;
+      clientTable.addEventListener('click', e=>{
+        const nameCell = e.target.closest('.client-name');
+        if(!nameCell) return;
+        currentClientRow = nameCell.parentElement;
+        const cells = currentClientRow.children;
+        clientNameEl.textContent = cells[0].textContent.trim();
+        clientCompany.textContent = cells[1].textContent.trim();
+        const email = cells[2].textContent.trim();
+        clientEmail.innerHTML = `<a href="mailto:${email}">${email}</a>`;
+        clientPhone.textContent = cells[3].textContent.trim();
+        clientStage.textContent = cells[4].querySelector('select').value;
+        clientOwner.textContent = cells[5].textContent.trim();
+        clientAddress.textContent = currentClientRow.dataset.address || '';
+        clientNotes.value = currentClientRow.dataset.notes || '';
+        clientMap.href = 'https://www.google.com/maps?q='+encodeURIComponent(clientAddress.textContent.trim());
+        clientModal.classList.remove('hidden');
+      });
+      clientAddress.addEventListener('blur',()=>{
+        clientMap.href = 'https://www.google.com/maps?q='+encodeURIComponent(clientAddress.textContent.trim());
+      });
+      function saveClientDetails(){
+        if(!currentClientRow) return;
+        currentClientRow.dataset.address = clientAddress.textContent.trim();
+        currentClientRow.dataset.notes = clientNotes.value.trim();
+      }
+      if(clientClose){ clientClose.addEventListener('click',()=>{ saveClientDetails(); clientModal.classList.add('hidden'); }); }
+      if(clientModal){ clientModal.addEventListener('click', e=>{ if(e.target===clientModal.firstElementChild){ saveClientDetails(); clientModal.classList.add('hidden'); } }); }
+
+    // Project Tasks (Kanban)
+    const taskColumns = {
+      todo: document.getElementById('todo-list'),
+      progress: document.getElementById('progress-list'),
+      done: document.getElementById('done-list')
+    };
+    let tasks = [];
+    function loadTasks(){
+      const saved = localStorage.getItem('kanban-tasks');
+      if(saved){
+        try{ tasks = JSON.parse(saved); }catch(e){ tasks = []; }
+      }
+      if(!tasks.length){
+        tasks = [
+          {id:1,title:'Launch Onboarding Flow',due:'2024-09-05',status:'todo',checked:false},
+          {id:2,title:'Proposal for Blue Sky Studio',due:'2024-08-28',status:'progress',checked:false},
+          {id:3,title:'Kickoff – Acme Co.',due:'2024-08-20',status:'done',checked:true}
+        ];
+      }
+      tasks = tasks.map(t=>({...t,checked:!!t.checked}));
+    }
+    function saveTasks(){ localStorage.setItem('kanban-tasks', JSON.stringify(tasks)); }
+    function renderTasks(){
+      Object.values(taskColumns).forEach(col=>col.innerHTML='');
+      tasks.forEach(t=>{
+        const col = taskColumns[t.status];
+        if(!col) return;
+        const div = document.createElement('div');
+        div.className = 'task'+(t.checked?' checked':'');
+        div.dataset.id = t.id;
+        div.draggable = true;
+        div.innerHTML = `<div style=\"display:flex;align-items:center;gap:6px;\"><div class=\"checkbox ${t.checked?'checked':''}\" data-check></div><div contenteditable class=\"task-title\">${t.title}</div></div><div class=\"mini\">Due: <input type=\"date\" class=\"task-due\" value=\"${t.due||''}\" /></div>`;
+        col.appendChild(div);
+      });
+      updateInsights();
+      renderWorkflow();
+    }
+    function addTask(status,title,due){
+      const id = Date.now();
+      tasks.push({id,title,due,status,checked:status==='done'});
+      saveTasks();
+      renderTasks();
+    }
+      document.querySelectorAll('.add-task').forEach(btn=>{
+        btn.addEventListener('click', ()=>{
+          const status = btn.dataset.status;
+          const title = document.getElementById(`${status}-new-title`).value.trim();
+          const due = document.getElementById(`${status}-new-due`).value;
+          if(!title) return;
+          addTask(status,title,due);
+          document.getElementById(`${status}-new-title`).value='';
+          document.getElementById(`${status}-new-due`).value='';
+        });
+      });
+
+      const templateSelect = document.getElementById('task-template');
+      const addTemplateBtn = document.getElementById('add-template');
+      if(addTemplateBtn){
+        addTemplateBtn.addEventListener('click', ()=>{
+          const title = templateSelect.value.trim();
+          if(!title) return;
+          const due = new Date(); due.setDate(due.getDate()+7);
+          addTask('todo', title, due.toISOString().split('T')[0]);
+          templateSelect.value='';
+        });
+      }
+
+      document.addEventListener('change', e=>{
+        if(e.target.classList.contains('stage-select')){
+          const row = e.target.closest('tr');
+          const name = row && row.children[0] ? row.children[0].textContent.trim() : '';
+          if(e.target.value==='Proposal' && name){
+            const title = `Follow up with ${name} after proposal`;
+            if(!tasks.some(t=>t.title===title)){
+              const due = new Date(); due.setDate(due.getDate()+3);
+              addTask('todo', title, due.toISOString().split('T')[0]);
+            }
+          }
+        }
+      });
+
+      // Daily tasks
+      const dailyList = document.getElementById('daily-list');
+      let dailyTasks = [];
+      function loadDaily(){
+        const saved = localStorage.getItem('daily-tasks');
+        if(saved){ try{ dailyTasks = JSON.parse(saved); }catch{ dailyTasks=[]; } }
+        if(!dailyTasks.length){
+          dailyTasks = [
+            {id:1,title:'Call: Jordan Lee (Acme Co.)',due:'2024-09-02',checked:false},
+            {id:2,title:'Call: Priya Shah (Blue Sky Studio)',due:'2024-09-02',checked:false},
+            {id:3,title:'Call: Alex Rivera (Zenith Group)',due:'2024-09-02',checked:false},
+            {id:4,title:'Wellness: Stretch for 5 minutes',due:'',checked:false},
+            {id:5,title:'Wellness: Drink water (250 ml)',due:'',checked:false}
+          ];
+        }
+      }
+      function saveDaily(){ localStorage.setItem('daily-tasks', JSON.stringify(dailyTasks)); }
+      function renderDaily(){
+        if(!dailyList) return;
+        dailyList.innerHTML='';
+        dailyTasks.forEach(t=>{
+          const div=document.createElement('div');
+          div.className='task'+(t.checked?' checked':'');
+          div.dataset.id=t.id;
+          div.innerHTML=`<div style="display:flex;align-items:center;gap:6px;"><div class="checkbox ${t.checked?'checked':''}" data-check></div><div contenteditable class="task-title">${t.title}</div></div><div class="mini">Due: <span contenteditable class="task-due">${t.due||''}</span></div>`;
+          dailyList.appendChild(div);
+        });
+      }
+      const addDaily=document.getElementById('daily-add');
+      if(addDaily){
+        addDaily.addEventListener('click',()=>{
+          const title=document.getElementById('daily-new-title').value.trim();
+          const due=document.getElementById('daily-new-due').value;
+          if(!title) return;
+          dailyTasks.push({id:Date.now(),title,due,checked:false});
+          saveDaily(); renderDaily();
+          document.getElementById('daily-new-title').value='';
+          document.getElementById('daily-new-due').value='';
+        });
+      }
+      loadDaily();
+      renderDaily();
+
+      // Task notes storage
+      let taskNotes = {};
+      const savedNotes = localStorage.getItem('task-notes');
+      if(savedNotes){ try{ taskNotes = JSON.parse(savedNotes); }catch{ taskNotes = {}; } }
+      document.addEventListener('blur', (e)=>{
+        const taskEl = e.target.closest('.task');
+        if(!taskEl) return;
+        const id = Number(taskEl.dataset.id);
+        const task = tasks.find(t=>t.id===id);
+        if(task){
+          task.title = taskEl.querySelector('.task-title').textContent.trim();
+          saveTasks();
+          updateInsights();
+          renderWorkflow();
+        }else{
+          const d = dailyTasks.find(t=>t.id===id);
+          if(d){
+            d.title = taskEl.querySelector('.task-title').textContent.trim();
+            d.due = taskEl.querySelector('.task-due')?.textContent.trim() || '';
+            saveDaily();
+          }
+        }
+      }, true);
+
+      document.addEventListener('change', (e)=>{
+        const taskEl = e.target.closest('.task');
+        if(!taskEl) return;
+        if(e.target.classList.contains('task-due')){
+          const id = Number(taskEl.dataset.id);
+          const task = tasks.find(t=>t.id===id);
+          if(task){
+            task.due = e.target.value;
+            saveTasks();
+            updateInsights();
+            renderWorkflow();
+          }else{
+            const d = dailyTasks.find(t=>t.id===id);
+            if(d){ d.due = e.target.value; saveDaily(); }
+          }
+        }
+      }, true);
+      document.addEventListener('click', (e)=>{
+        const box = e.target.closest('.checkbox');
+        if(!box) return;
+        const taskEl = box.closest('.task');
+        const id = Number(taskEl.dataset.id);
+        const task = tasks.find(t=>t.id===id);
+        if(task){
+          task.checked = !task.checked;
+          box.classList.toggle('checked', task.checked);
+          taskEl.classList.toggle('checked', task.checked);
+          saveTasks();
+          updateInsights();
+        }else{
+          const d = dailyTasks.find(t=>t.id===id);
+          if(d){
+            d.checked = !d.checked;
+            box.classList.toggle('checked', d.checked);
+            taskEl.classList.toggle('checked', d.checked);
+            saveDaily();
+          }else{
+            const isChecked = box.classList.toggle('checked');
+            taskEl.classList.toggle('checked', isChecked);
+          }
+        }
+      });
+      function updateInsights(){
+        const today = new Date().toISOString().split('T')[0];
+        const overdue = tasks.filter(t=>!t.checked && t.due && t.due<today);
+        const completed = tasks.filter(t=>t.checked);
+        const overdueList = document.getElementById('overdue-list');
+        const completedList = document.getElementById('completed-list');
+        const overdueCount = document.getElementById('overdue-count');
+        const completedCount = document.getElementById('completed-count');
+        const workloadMetrics = document.getElementById('workload-metrics');
+        if(overdueCount){ overdueCount.textContent = `${overdue.length} overdue`; }
+        if(completedCount){ completedCount.textContent = `${completed.length} completed`; }
+        if(workloadMetrics){ workloadMetrics.innerHTML = `<li>Hours worked: 40</li><li>Breaks: 5</li><li>Tasks completed: ${completed.length}</li>`; }
+        if(overdueList){
+          overdueList.innerHTML = overdue.length ? overdue.map(t=>`<li>${t.title} (Due: ${t.due})</li>`).join('') : '<li>None</li>';
+        }
+        if(completedList){
+          completedList.innerHTML = completed.length ? completed.map(t=>`<li>${t.title}</li>`).join('') : '<li>None</li>';
+        }
+        renderCharts();
+      }
+
+      const barData = {};
+      const tooltip = document.createElement('div');
+      tooltip.id='chart-tooltip';
+      document.body.appendChild(tooltip);
+      function renderCharts(){
+        const overdueCtx = document.getElementById('overdue-chart')?.getContext('2d');
+        const completedCtx = document.getElementById('completed-chart')?.getContext('2d');
+        const personalCtx = document.getElementById('personal-mood-chart')?.getContext('2d');
+        const teamCtx = document.getElementById('team-mood-chart')?.getContext('2d');
+        const workloadCtx = document.getElementById('workload-chart')?.getContext('2d');
+        const labels = ['Sep 1','Sep 2','Sep 3','Sep 4','Sep 5'];
+        const moodLabels = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+        if(overdueCtx){ drawBars(overdueCtx, [3,5,2,4,6], '#ef4444', labels); }
+        if(completedCtx){ drawBars(completedCtx, [1,3,5,4,7], '#16a34a', labels); }
+        if(workloadCtx){ drawBars(workloadCtx, [6,7,5,8,6], '#4f46e5', labels); }
+        if(personalCtx){ drawBars(personalCtx, moodData, '#6b46c1', moodLabels.slice(-moodData.length)); }
+        if(teamCtx){ drawBars(teamCtx, [3,4,2,5,4,3,4], '#8b5cf6', moodLabels); }
+      }
+      function drawBars(ctx,data,color,labels){
+        const id = ctx.canvas.id;
+        const w=ctx.canvas.width, h=ctx.canvas.height;
+        ctx.clearRect(0,0,w,h);
+        const bw=w/(data.length*2);
+        barData[id]=[];
+        data.forEach((v,i)=>{
+          const x=(i*2+1)*bw;
+          const barH=v*20;
+          const y=h-barH;
+          ctx.fillStyle=color;
+          ctx.fillRect(x,y,bw,barH);
+          barData[id].push({x,y,w:bw,h:barH,label:labels[i],value:v});
+        });
+        if(!ctx.canvas.dataset.tooltipAttached){
+          ctx.canvas.addEventListener('mousemove',e=>{
+            const rect=ctx.canvas.getBoundingClientRect();
+            const x=e.clientX-rect.left, y=e.clientY-rect.top;
+            const bar=barData[id].find(b=>x>=b.x && x<=b.x+b.w && y>=b.y && y<=b.y+b.h);
+            if(bar){
+              tooltip.style.display='block';
+              tooltip.textContent=`${bar.label}: ${bar.value} tasks`;
+              tooltip.style.left=(e.clientX+10)+'px';
+              tooltip.style.top=(e.clientY+10)+'px';
+            }else{ tooltip.style.display='none'; }
+          });
+          ctx.canvas.addEventListener('mouseleave',()=> tooltip.style.display='none');
+          ctx.canvas.dataset.tooltipAttached='1';
+        }
+      }
+
+      function renderWorkflow(){
+        const ctx = document.getElementById('workflow-chart')?.getContext('2d');
+        if(!ctx) return;
+        const labels = tasks.map(t=>t.title);
+        const data = tasks.map(t=> t.status==='done'?5 : t.status==='progress'?2.5 : 0);
+        drawBars(ctx, data, '#6366f1', labels);
+      }
+    loadTasks();
+    renderTasks();
+
+    // Kanban drag and drop
+    let draggedTaskId = null;
+    let draggedPerson = null;
+    document.addEventListener('dragstart', e=>{
+      const taskEl = e.target.closest('.task');
+      if(taskEl && taskEl.dataset.id){ draggedTaskId = Number(taskEl.dataset.id); }
+      if(taskEl && taskEl.closest('#pipeline')){ draggedPerson = taskEl; }
+    });
+    document.querySelectorAll('.kanban .column').forEach(col=>{
+      col.addEventListener('dragover', e=>e.preventDefault());
+      col.addEventListener('drop', e=>{
+        e.preventDefault();
+        if(draggedTaskId!==null){
+          const newStatus = col.dataset.status;
+          const task = tasks.find(t=>t.id===draggedTaskId);
+          if(task && newStatus){ task.status = newStatus; saveTasks(); renderTasks(); }
+        }
+      });
+    });
+
+    // Pipeline drag and drop
+    document.querySelectorAll('#pipeline .task').forEach(t=>{
+      t.addEventListener('dragstart', ()=> draggedPerson = t);
+    });
+    document.querySelectorAll('#pipeline .column').forEach(col=>{
+      col.addEventListener('dragover', e=>e.preventDefault());
+      col.addEventListener('drop', ()=>{
+        if(draggedPerson){ col.appendChild(draggedPerson); draggedPerson=null; }
+      });
+    });
+
+    // Calendar upcoming items
+    const upcomingList = document.getElementById('upcoming-list');
+    let upcoming = [];
+    function loadUpcoming(){
+      const saved = localStorage.getItem('calendar-upcoming');
+      if(saved){ try{ upcoming = JSON.parse(saved); }catch{ upcoming=[]; } }
+      if(!upcoming.length){
+        upcoming = [
+          {title:'Client Call – Acme Co.', time:'2024-09-02T10:00'},
+          {title:'Proposal Review – Blue Sky', time:'2024-09-03T14:00'},
+          {title:'Onboarding Session', time:'2024-09-05T09:00'}
+        ];
+      }
+    }
+    function saveUpcoming(){ localStorage.setItem('calendar-upcoming', JSON.stringify(upcoming)); }
+    function renderUpcoming(){
+      if(!upcomingList) return;
+      upcomingList.innerHTML='';
+      upcoming.forEach((u,i)=>{
+        const div=document.createElement('div');
+        div.className='task';
+        div.dataset.index=i;
+        div.innerHTML=`<div contenteditable class="task-title">${u.title}</div><input type="datetime-local" class="up-time" value="${u.time}" style="flex:1"/><button class="btn link remove-upcoming">Remove</button>`;
+        upcomingList.appendChild(div);
+      });
+    }
+    const addUpcoming=document.getElementById('add-upcoming');
+    if(addUpcoming){
+      addUpcoming.addEventListener('click',()=>{
+        const title=document.getElementById('upcoming-title').value.trim();
+        const date=document.getElementById('upcoming-date').value;
+        if(!title) return;
+        upcoming.push({title,time:date});
+        saveUpcoming(); renderUpcoming();
+        document.getElementById('upcoming-title').value='';
+        document.getElementById('upcoming-date').value='';
+      });
+    }
+    if(upcomingList){
+      upcomingList.addEventListener('click',e=>{
+        if(e.target.closest('.remove-upcoming')){
+          const idx=Number(e.target.closest('.task').dataset.index);
+          upcoming.splice(idx,1); saveUpcoming(); renderUpcoming();
+        }
+      });
+      upcomingList.addEventListener('blur',e=>{
+        const item=e.target.closest('.task');
+        if(!item) return;
+        const idx=Number(item.dataset.index);
+        upcoming[idx].title=item.querySelector('.task-title').textContent.trim();
+        saveUpcoming();
+      },true);
+      upcomingList.addEventListener('change',e=>{
+        const item=e.target.closest('.task');
+        if(!item) return;
+        const idx=Number(item.dataset.index);
+        if(e.target.classList.contains('up-time')){
+          upcoming[idx].time=e.target.value;
+          saveUpcoming();
+        }
+      });
+    }
+      loadUpcoming(); renderUpcoming();
+
+      // Mental health chart
+      const moodLine = document.getElementById('mood-line');
+      const moodDots = document.getElementById('mood-dots');
+      let moodData = [2,3,4,3,5,4,3];
+      function renderMood(){
+        const base=160;
+        moodDots.innerHTML='';
+        const pts=[];
+        moodData.forEach((v,i)=>{
+          const x=10+i*45;
+          const y=base - v*20;
+          pts.push(`${x},${y}`);
+          const c=document.createElementNS('http://www.w3.org/2000/svg','circle');
+          c.setAttribute('cx',x);c.setAttribute('cy',y);c.setAttribute('r',4);
+          const d=new Date();
+          d.setDate(d.getDate()-(moodData.length-1-i));
+          const label=d.toLocaleDateString('en-US',{month:'short',day:'numeric'});
+          c.addEventListener('mousemove',e=>{
+            tooltip.style.display='block';
+            tooltip.textContent=`${label}: ${v}`;
+            tooltip.style.left=(e.clientX+10)+'px';
+            tooltip.style.top=(e.clientY+10)+'px';
+          });
+          c.addEventListener('mouseleave',()=>tooltip.style.display='none');
+          moodDots.appendChild(c);
+        });
+        moodLine.setAttribute('points', pts.join(' '));
+      }
+      renderMood();
+      const logMoodBtn = document.getElementById('log-mood');
+        if(logMoodBtn){
+          logMoodBtn.addEventListener('click',()=>{
+            const val=Number(document.getElementById('mood-today').value);
+            moodData.push(val);
+            if(moodData.length>7) moodData.shift();
+            renderMood();
+          });
+        }
+
+        // Wellness survey
+        const surveyBtn = document.getElementById('start-survey');
+        const surveyModal = document.getElementById('survey-modal');
+        const surveyTitle = document.getElementById('survey-title');
+        const surveyQuestion = document.getElementById('survey-question');
+        const surveyOptions = document.getElementById('survey-options');
+        const surveyFeedback = document.getElementById('survey-feedback');
+        const surveyNext = document.getElementById('survey-next');
+        const surveyClose = document.getElementById('survey-close');
+        const POSITIVE_MSG = 'Great! Keep working hard.';
+        const surveyQs = [
+          { q:'In the past two weeks, how often have you felt overwhelmed by your workload?', options:[
+            {text:'Rarely or never', positive:true},
+            {text:'Sometimes', positive:true},
+            {text:'Often', positive:false, msg:'👉 Reminder: It’s okay to feel stretched sometimes, but chronic stress can harm your health. Try breaking tasks into smaller steps, delegating where possible, and scheduling brief recharge breaks. Your well-being matters more than perfection.'},
+            {text:'Almost always', positive:false, msg:'👉 Reminder: It’s okay to feel stretched sometimes, but chronic stress can harm your health. Try breaking tasks into smaller steps, delegating where possible, and scheduling brief recharge breaks. Your well-being matters more than perfection.'}
+          ]},
+          { q:'Do you generally feel rested and energized at the start of your workday?', options:[
+            {text:'Yes, consistently', positive:true},
+            {text:'Sometimes', positive:true},
+            {text:'Rarely', positive:false, msg:'👉 Sleep and rest are essential to clear thinking and productivity. Aim for consistent bedtime routines and short daily rituals (stretching, journaling, breathing) to signal rest. Even small improvements can add up to big gains in energy.'}
+          ]},
+          { q:'How easy is it for you to concentrate on important tasks?', options:[
+            {text:'Easy', positive:true},
+            {text:'Somewhat difficult', positive:false, msg:'👉 Focus can be trained. Try using short focus intervals (like 25 minutes on, 5 minutes off), silencing notifications, and tackling your hardest task first. Your brain works best in sprints, not marathons.'},
+            {text:'Very difficult', positive:false, msg:'👉 Focus can be trained. Try using short focus intervals (like 25 minutes on, 5 minutes off), silencing notifications, and tackling your hardest task first. Your brain works best in sprints, not marathons.'}
+          ]},
+          { q:'Do you feel you can prioritize your work without constant rework or interruption?', options:[
+            {text:'Yes', positive:true},
+            {text:'Sometimes', positive:false, msg:'👉 When priorities shift too often, it helps to clarify what matters most. Aligning with your manager or team on the “top 3” priorities can reduce stress. Remember—focus on impact, not endless busyness.'},
+            {text:'No', positive:false, msg:'👉 When priorities shift too often, it helps to clarify what matters most. Aligning with your manager or team on the “top 3” priorities can reduce stress. Remember—focus on impact, not endless busyness.'}
+          ]},
+          { q:'Do you feel you can disconnect from work after hours?', options:[
+            {text:'Yes, easily', positive:true},
+            {text:'Sometimes', positive:true},
+            {text:'Rarely', positive:false, msg:'👉 Healthy boundaries are vital. Try creating a “shutdown ritual” at day’s end—write tomorrow’s to-do list, close your laptop, and step away. Protecting personal time strengthens both mental health and workplace performance.'}
+          ]},
+          { q:'Do you feel motivated and inspired to do your best work most days?', options:[
+            {text:'Yes', positive:true},
+            {text:'Sometimes', positive:false, msg:'👉 Motivation often grows when work feels meaningful. Reflect on how your role supports others, and celebrate small wins each day. Even small steps forward count as real progress.'},
+            {text:'No', positive:false, msg:'👉 Motivation often grows when work feels meaningful. Reflect on how your role supports others, and celebrate small wins each day. Even small steps forward count as real progress.'}
+          ]},
+          { q:'Do you feel your contributions are recognized and valued?', options:[
+            {text:'Yes', positive:true},
+            {text:'Sometimes', positive:false, msg:'👉 You deserve to be seen. If recognition feels lacking, share your progress with teammates or keep a “done list” to celebrate yourself. Recognition starts inside, but don’t hesitate to voice your wins.'},
+            {text:'No', positive:false, msg:'👉 You deserve to be seen. If recognition feels lacking, share your progress with teammates or keep a “done list” to celebrate yourself. Recognition starts inside, but don’t hesitate to voice your wins.'}
+          ]},
+          { q:'Do you feel comfortable asking for help when work feels overwhelming?', options:[
+            {text:'Yes', positive:true},
+            {text:'Sometimes', positive:false, msg:'👉 Reaching out shows strength, not weakness. Whether it’s a manager, coworker, or wellness resource, support networks exist to help lighten your load. You’re not meant to carry everything alone.'},
+            {text:'No', positive:false, msg:'👉 Reaching out shows strength, not weakness. Whether it’s a manager, coworker, or wellness resource, support networks exist to help lighten your load. You’re not meant to carry everything alone.'}
+          ]},
+          { q:'In the past month, have stress or mental health challenges caused you to miss work or work while unwell?', options:[
+            {text:'No', positive:true},
+            {text:'Occasionally', positive:false, msg:'👉 Your health is the foundation of your work. Taking time to rest and recover is not a failure—it’s an investment. Prioritize care when needed, and you’ll return stronger and clearer.'},
+            {text:'Frequently', positive:false, msg:'👉 Your health is the foundation of your work. Taking time to rest and recover is not a failure—it’s an investment. Prioritize care when needed, and you’ll return stronger and clearer.'}
+          ]},
+          { q:'How would you rate your overall mental well-being right now?', options:[
+            {text:'Good', positive:true},
+            {text:'Fair', positive:false, msg:'👉 Remember: well-being is a journey, not a destination. Small habits like daily movement, connecting with a friend, or practicing gratitude can shift your mindset over time. Progress, not perfection, is the goal.'},
+            {text:'Poor', positive:false, msg:'👉 Remember: well-being is a journey, not a destination. Small habits like daily movement, connecting with a friend, or practicing gratitude can shift your mindset over time. Progress, not perfection, is the goal.'}
+          ]}
+        ];
+        let surveyIndex=0;
+        function renderSurvey(){
+          const q=surveyQs[surveyIndex];
+          surveyTitle.textContent = `Question ${surveyIndex+1} of ${surveyQs.length}`;
+          surveyQuestion.textContent = q.q;
+          surveyOptions.innerHTML='';
+          q.options.forEach((opt,i)=>{
+            const label=document.createElement('label');
+            label.style.display='block';
+            label.style.margin='6px 0';
+            const input=document.createElement('input');
+            input.type='radio'; input.name='survey-opt'; input.value=i;
+            label.appendChild(input);
+            label.append(' '+opt.text);
+            surveyOptions.appendChild(label);
+          });
+          surveyFeedback.textContent='';
+          surveyNext.textContent = surveyIndex < surveyQs.length-1 ? 'Next' : 'Finish';
+          surveyNext.disabled=true;
+        }
+        function handleSelection(){
+          const sel=document.querySelector('input[name="survey-opt"]:checked');
+          if(!sel){ surveyNext.disabled=true; return; }
+          const opt=surveyQs[surveyIndex].options[Number(sel.value)];
+          surveyFeedback.textContent = opt.positive ? POSITIVE_MSG : opt.msg;
+          surveyNext.disabled=false;
+        }
+        function nextSurvey(){
+          const sel=document.querySelector('input[name="survey-opt"]:checked');
+          if(!sel) return;
+          surveyIndex++;
+          if(surveyIndex<surveyQs.length){
+            renderSurvey();
+          }else{
+            surveyModal.classList.add('hidden');
+          }
+        }
+        if(surveyBtn){
+          surveyBtn.addEventListener('click',()=>{
+            surveyIndex=0;
+            renderSurvey();
+            surveyModal.classList.remove('hidden');
+          });
+        }
+        if(surveyOptions){ surveyOptions.addEventListener('change',handleSelection); }
+        if(surveyNext){ surveyNext.addEventListener('click',nextSurvey); }
+        if(surveyClose){ surveyClose.addEventListener('click',()=>surveyModal.classList.add('hidden')); }
+        if(surveyModal){
+          surveyModal.addEventListener('click',e=>{ if(e.target===surveyModal.firstElementChild){ surveyModal.classList.add('hidden'); } });
+        }
+
+        // Task detail modal
+        const taskModal = document.getElementById('task-modal');
+      const modalTitle = document.getElementById('modal-title');
+      const modalDue = document.getElementById('modal-due');
+      const modalNote = document.getElementById('modal-note');
+      const modalContact = document.getElementById('modal-contact');
+      const modalClose = document.getElementById('modal-close');
+      function findCRMContactFromTitle(title){
+        const match = title.match(/(?:Call|Email):\s*([^()]+)/i);
+        if(match){
+          const name = match[1].trim().toLowerCase();
+          const row = [...clientTable.querySelectorAll('tr')].find(r=>r.children[0].textContent.trim().toLowerCase()===name);
+          if(row){ return {name: row.children[0].textContent.trim(), id: row.id}; }
+        }
+        return null;
+      }
+      function saveTaskModal(){
+        const key = taskModal.dataset.key;
+        if(key){ taskNotes[key]=modalNote.value.trim(); localStorage.setItem('task-notes', JSON.stringify(taskNotes)); }
+        const source = taskModal.dataset.source;
+        const id = taskModal.dataset.id;
+        const dueVal = modalDue.value;
+        if(source==='kanban'){
+          const t = tasks.find(x=>x.id===Number(id));
+          if(t){ t.due = dueVal?dueVal.split('T')[0]:''; saveTasks(); renderTasks(); }
+        }else if(source==='daily'){
+          const d = dailyTasks.find(x=>x.id===Number(id));
+          if(d){ d.due = dueVal?dueVal.split('T')[0]:''; saveDaily(); renderDaily(); }
+        }else if(source==='upcoming'){
+          const idx = Number(id);
+          if(upcoming[idx]){ upcoming[idx].time = dueVal; saveUpcoming(); renderUpcoming(); }
+        }
+        taskModal.classList.add('hidden');
+      }
+      if(taskModal){
+        taskModal.addEventListener('click', e=>{ if(e.target===taskModal.firstElementChild){ saveTaskModal(); } });
+      }
+      if(modalClose){ modalClose.addEventListener('click', saveTaskModal); }
+    function openTaskDetails(taskEl){
+      let title='', due='', source='', id='';
+      if(taskEl.dataset.id){
+        const t = tasks.find(x=>x.id===Number(taskEl.dataset.id));
+        if(t){ title=t.title; due=t.due||''; source='kanban'; id=t.id; }
+      }else if(taskEl.closest('#upcoming-list')){
+        const idx = Number(taskEl.dataset.index);
+        const u = upcoming[idx];
+        title = u.title; due = u.time; source='upcoming'; id=idx;
+      }else if(taskEl.closest('#page-daily')){
+        const d = dailyTasks.find(x=>x.id===Number(taskEl.dataset.id));
+        if(d){ title=d.title; due=d.due||''; source='daily'; id=d.id; }
+      }else if(taskEl.closest('#pipeline')){
+        title = taskEl.textContent.trim();
+        due = taskEl.parentElement.dataset.stage || '';
+        source='pipeline';
+      }
+      if(title){
+        modalTitle.textContent=title;
+        modalDue.value = due ? (due.includes('T')?due:due+'T00:00') : '';
+        modalNote.value = taskNotes[title] || '';
+        const contact = findCRMContactFromTitle(title);
+        if(contact){
+          modalContact.innerHTML = `<a href="#page-crm" class="crm-link" data-target="${contact.id}">View contact: ${contact.name}</a>`;
+        }else{
+          modalContact.textContent='';
+        }
+        taskModal.dataset.key = title;
+        taskModal.dataset.source = source;
+        taskModal.dataset.id = id;
+        taskModal.classList.remove('hidden');
+      }
+    }
+
+    const dailyListEl = document.getElementById('daily-list');
+    if(dailyListEl){
+      dailyListEl.addEventListener('click',e=>{
+        if(e.target.closest('.checkbox')||e.target.tagName==='A') return;
+        const taskEl = e.target.closest('.task');
+        if(taskEl) openTaskDetails(taskEl);
+      });
+    }
+
+    document.addEventListener('click', e=>{
+      if(e.target.closest('#daily-list')||e.target.closest('.checkbox')||e.target.closest('.remove-upcoming')||e.target.classList.contains('up-time')||e.target.classList.contains('task-due')||e.target.hasAttribute('contenteditable')||e.target.closest('[contenteditable]')||e.target.tagName==='A') return;
+      const taskEl = e.target.closest('.task');
+      if(!taskEl || taskEl.closest('#task-modal')) return;
+      openTaskDetails(taskEl);
+    });
 
     // Done for the Day overlay
     const doneBtn = document.getElementById('done-day');


### PR DESCRIPTION
## Summary
- link each AI assistant prompt to ChatGPT with prefilled text
- allow Kanban tasks to edit due dates and visualize progress in a workflow chart
- show personal and team mental-health charts in the Insights dashboard
- enable upcoming events to be rescheduled via a modal time picker
- enlarge CRM client table, add task templates, and display workload balance metrics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a7a7830da083319e2eb4036762d20e