### PR TITLE
feat: add robust JSON parsing and proxy responses

### DIFF
--- a/index.html
+++ b/index.html
@@ -1449,7 +1449,21 @@ async function sendCRM(message) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ input: message })
   });
-  return await res.json();
+  const dataText = await res.text();
+  let data;
+  try {
+    data = JSON.parse(dataText);
+  } catch {
+    data = { raw: dataText };
+  }
+  if (!res.ok) {
+    const err = new Error(
+      (data && (data.error || data.message)) || `HTTP ${res.status}`
+    );
+    err.raw = dataText;
+    throw err;
+  }
+  return data;
 }
 // Example usage:
 // sendCRM("Create a task for client 123: demo on 2025-09-01 17:00Z").then(console.log);
@@ -1482,10 +1496,12 @@ async function sendMessage(message) {
   inputEl.value = '';
   try {
     const data = await sendCRM(message);
-    const reply = data?.data?.message || data?.message || '(no response)';
+    const reply =
+      data?.data?.message || data?.message || data?.raw || 'No response';
     append('Assistant', reply);
   } catch (e) {
     append('Assistant', 'Error: ' + e.message);
+    console.error('Raw response:', e.raw);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -1443,8 +1443,9 @@
   </script>
 
 <script>
+const PROXY_URL = '/.netlify/functions/run-crm-assistant';
 async function sendCRM(message) {
-  const res = await fetch('/.netlify/functions/run-crm-assistant', {
+  const res = await fetch(PROXY_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ input: message })
@@ -1467,6 +1468,12 @@ async function sendCRM(message) {
 }
 // Example usage:
 // sendCRM("Create a task for client 123: demo on 2025-09-01 17:00Z").then(console.log);
+// Or test directly:
+// fetch(PROXY_URL, {
+//   method: 'POST',
+//   headers: { 'Content-Type': 'application/json' },
+//   body: JSON.stringify({ input: "I'm kinda tired" })
+// }).then(r => r.text()).then(console.log).catch(console.error);
 </script>
 
 <!-- Sim.ai chat widget -->

--- a/netlify/functions/run-crm-assistant.js
+++ b/netlify/functions/run-crm-assistant.js
@@ -1,8 +1,18 @@
+const corsHeaders = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS'
+};
+
 export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: corsHeaders, body: '' };
+  }
   if (event.httpMethod !== 'POST') {
     return {
       statusCode: 405,
-      headers: { 'Content-Type': 'application/json' },
+      headers: corsHeaders,
       body: JSON.stringify({ error: 'Method Not Allowed' })
     };
   }
@@ -11,7 +21,7 @@ export async function handler(event) {
     if (!input || typeof input !== 'string') {
       return {
         statusCode: 400,
-        headers: { 'Content-Type': 'application/json' },
+        headers: corsHeaders,
         body: JSON.stringify({ error: 'Missing input (string)' })
       };
     }
@@ -20,7 +30,7 @@ export async function handler(event) {
     if (!simToken) {
       return {
         statusCode: 500,
-        headers: { 'Content-Type': 'application/json' },
+        headers: corsHeaders,
         body: JSON.stringify({ error: 'SIM_API_TOKEN not configured' })
       };
     }
@@ -47,13 +57,13 @@ export async function handler(event) {
 
     return {
       statusCode: res.status,
-      headers: { 'Content-Type': 'application/json' },
+      headers: corsHeaders,
       body: JSON.stringify(body)
     };
   } catch (err) {
     return {
       statusCode: 500,
-      headers: { 'Content-Type': 'application/json' },
+      headers: corsHeaders,
       body: JSON.stringify({ error: err.message })
     };
   }

--- a/netlify/functions/run-crm-assistant.js
+++ b/netlify/functions/run-crm-assistant.js
@@ -1,33 +1,60 @@
 export async function handler(event) {
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, body: 'Method Not Allowed' };
+    return {
+      statusCode: 405,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Method Not Allowed' })
+    };
   }
   try {
     const { input } = JSON.parse(event.body || '{}');
     if (!input || typeof input !== 'string') {
-      return { statusCode: 400, body: 'Missing input (string)' };
+      return {
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'Missing input (string)' })
+      };
     }
 
     const simToken = process.env.SIM_API_TOKEN;
     if (!simToken) {
-      return { statusCode: 500, body: 'SIM_API_TOKEN not configured' };
+      return {
+        statusCode: 500,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'SIM_API_TOKEN not configured' })
+      };
     }
 
-    const res = await fetch('https://www.sim.ai/api/workflows/25142af3-518e-4882-8d5d-f198a1e5e6ea/execute', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-API-Key': simToken
-      },
-      body: JSON.stringify({ message: input })
-    });
+    const res = await fetch(
+      'https://www.sim.ai/api/workflows/25142af3-518e-4882-8d5d-f198a1e5e6ea/execute',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': simToken
+        },
+        body: JSON.stringify({ message: input })
+      }
+    );
 
-    const data = await res.json().catch(() => ({}));
+    const txt = await res.text();
+    let body;
+    try {
+      body = JSON.parse(txt);
+    } catch {
+      body = { raw: txt };
+    }
+
     return {
       statusCode: res.status,
-      body: JSON.stringify(data)
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
     };
   } catch (err) {
-    return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: err.message })
+    };
   }
 }


### PR DESCRIPTION
## Summary
- safely parse proxy responses in the client and surface errors
- return JSON with content-type in Netlify function, including raw text fallback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a8da5a0b748331898daa1ee65ea67d