### PR TITLE
Add dashboard KPIs and task summary

### DIFF
--- a/client-onboarding-tasks.md
+++ b/client-onboarding-tasks.md
@@ -1,0 +1,30 @@
+# Client Onboarding Tasks
+
+## Immediate Tasks
+
+- Verify client records
+- Check for duplicates
+- Store contact data
+- Assign an account manager
+- Place clients in the correct pipeline stage
+- Draft welcome messages
+- Schedule the first touchpoint
+
+## Early Relationship Tasks
+
+- Upload or request key documents
+- Schedule a kickoff or discovery call with AI-suggested agendas
+- Define success metrics
+- Auto-create initial project boards after a deal is won
+
+## Ongoing & AI-Driven Tasks
+
+- Automate reminders for follow-ups and daily task breakdowns
+- Update the pipeline as projects advance
+- Use a wellness layer to monitor workload and pace onboarding tasks
+
+Adding a client triggers an onboarding workflow:
+verify the record, assign ownership,
+send a welcome message, schedule a call,
+organize documents, initiate a project,
+and continue with automated nudges.

--- a/index.html
+++ b/index.html
@@ -162,6 +162,20 @@
           </div>
         </div>
       </div>
+      <div class="grid grid-2" style="margin-top:16px">
+        <div class="card kpi">
+          <h3>Revenue Generated</h3>
+          <p id="kpi-revenue">$0</p>
+        </div>
+        <div class="card kpi">
+          <h3>Time Saved</h3>
+          <p id="kpi-time">0h</p>
+        </div>
+      </div>
+      <div class="card" style="margin-top:16px">
+        <h3>Today's Tasks</h3>
+        <ul id="today-task-list"></ul>
+      </div>
     </section>
 
     <!-- CRM SNAPSHOT -->
@@ -781,6 +795,16 @@
       tasks = tasks.map(t=>({...t,checked:!!t.checked}));
     }
     function saveTasks(){ localStorage.setItem('kanban-tasks', JSON.stringify(tasks)); }
+    function updateDashboardTasks(){
+      const list=document.getElementById('today-task-list');
+      if(!list) return;
+      list.innerHTML='';
+      tasks.filter(t=>t.status!=='done').forEach(t=>{
+        const li=document.createElement('li');
+        li.textContent=t.title;
+        list.appendChild(li);
+      });
+    }
     function renderTasks(){
       Object.values(taskColumns).forEach(col=>col.innerHTML='');
       tasks.forEach(t=>{
@@ -795,6 +819,7 @@
       });
       updateInsights();
       renderWorkflow();
+      updateDashboardTasks();
     }
     function addTask(status,title,due){
       const id = Date.now();

--- a/index.html
+++ b/index.html
@@ -166,10 +166,12 @@
         <div class="card kpi">
           <h3>Revenue Generated</h3>
           <p id="kpi-revenue">$0</p>
+          <canvas id="revenue-chart" width="320" height="120" class="chart" aria-label="Revenue bar chart"></canvas>
         </div>
         <div class="card kpi">
           <h3>Time Saved</h3>
           <p id="kpi-time">0h</p>
+          <canvas id="time-chart" width="320" height="120" class="chart" aria-label="Time saved line chart"></canvas>
         </div>
       </div>
       <div class="card" style="margin-top:16px">
@@ -799,7 +801,7 @@
       const list=document.getElementById('today-task-list');
       if(!list) return;
       list.innerHTML='';
-      tasks.filter(t=>t.status!=='done').forEach(t=>{
+      dailyTasks.filter(t=>!t.checked).forEach(t=>{
         const li=document.createElement('li');
         li.textContent=t.title;
         list.appendChild(li);
@@ -819,7 +821,6 @@
       });
       updateInsights();
       renderWorkflow();
-      updateDashboardTasks();
     }
     function addTask(status,title,due){
       const id = Date.now();
@@ -896,6 +897,7 @@
           div.innerHTML=`<div style="display:flex;align-items:center;gap:6px;"><div class="checkbox ${t.checked?'checked':''}" data-check></div><div contenteditable class="task-title">${t.title}</div></div><div class="mini">Due: <input type="date" class="task-due" value="${t.due||todayStr}" /></div>${linkHTML}`;
           dailyList.appendChild(div);
         });
+        updateDashboardTasks();
       }
       const addDaily=document.getElementById('daily-add');
       const dailyDueInput=document.getElementById('daily-new-due');
@@ -1003,6 +1005,7 @@
       }
 
       const barData = {};
+      const lineData = {};
       const tooltip = document.createElement('div');
       tooltip.id='chart-tooltip';
       document.body.appendChild(tooltip);
@@ -1014,13 +1017,18 @@
         const personalCtx = document.getElementById('personal-mood-chart')?.getContext('2d');
         const teamCtx = document.getElementById('team-mood-chart')?.getContext('2d');
         const workloadCtx = document.getElementById('workload-chart')?.getContext('2d');
+        const revenueCtx = document.getElementById('revenue-chart')?.getContext('2d');
+        const timeCtx = document.getElementById('time-chart')?.getContext('2d');
         const labels = ['Sep 1','Sep 2','Sep 3','Sep 4','Sep 5'];
         const moodLabels = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+        const dayLabels = ['Mon','Tue','Wed','Thu','Fri'];
         if(overdueCtx){ drawBars(overdueCtx, [3,5,2,4,6], '#ef4444', labels); }
         if(completedCtx){ drawBars(completedCtx, [1,3,5,4,7], '#16a34a', labels); }
         if(workloadCtx){ drawBars(workloadCtx, [6,7,5,8,6], '#4f46e5', labels); }
         if(personalCtx){ drawBars(personalCtx, moodData, '#6b46c1', moodLabels.slice(-moodData.length)); }
         if(teamCtx){ drawBars(teamCtx, [3,4,2,5,4,3,4], '#8b5cf6', moodLabels); }
+        if(revenueCtx){ drawBars(revenueCtx, [200,350,150,400,500], '#4f46e5', dayLabels); }
+        if(timeCtx){ drawLine(timeCtx, [1,2,1.5,2.5,3], '#16a34a', dayLabels); }
       }
       function drawBars(ctx,data,color,labels){
         const id = ctx.canvas.id;
@@ -1048,6 +1056,41 @@
               tooltip.textContent = id==='workflow-chart'
                 ? `${bar.label}: ${bar.value}% complete`
                 : `${bar.label}: ${bar.value} tasks`;
+              tooltip.style.left=(e.clientX+10)+'px';
+              tooltip.style.top=(e.clientY+10)+'px';
+            }else{ tooltip.style.display='none'; }
+          });
+          ctx.canvas.addEventListener('mouseleave',()=> tooltip.style.display='none');
+          ctx.canvas.dataset.tooltipAttached='1';
+        }
+      }
+      function drawLine(ctx,data,color,labels){
+        const id = ctx.canvas.id;
+        const w=ctx.canvas.width, h=ctx.canvas.height;
+        ctx.clearRect(0,0,w,h);
+        const max=Math.max(...data);
+        const step=w/(data.length-1);
+        lineData[id]=[];
+        ctx.strokeStyle=color;
+        ctx.lineWidth=2;
+        ctx.beginPath();
+        data.forEach((v,i)=>{
+          const x=i*step;
+          const y=h-(v/max)*h;
+          if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+          lineData[id].push({x,y,label:labels[i],value:v});
+        });
+        ctx.stroke();
+        ctx.fillStyle=color;
+        lineData[id].forEach(p=>{ ctx.beginPath(); ctx.arc(p.x,p.y,3,0,Math.PI*2); ctx.fill(); });
+        if(!ctx.canvas.dataset.tooltipAttached){
+          ctx.canvas.addEventListener('mousemove',e=>{
+            const rect=ctx.canvas.getBoundingClientRect();
+            const x=e.clientX-rect.left, y=e.clientY-rect.top;
+            const pt=lineData[id].find(p=>Math.hypot(p.x-x,p.y-y)<5);
+            if(pt){
+              tooltip.style.display='block';
+              tooltip.textContent=`${pt.label}: ${pt.value}`;
               tooltip.style.left=(e.clientX+10)+'px';
               tooltip.style.top=(e.clientY+10)+'px';
             }else{ tooltip.style.display='none'; }

--- a/index.html
+++ b/index.html
@@ -550,21 +550,62 @@
     <!-- CLIENT DETAIL MODAL -->
     <section id="client-modal" class="hidden" aria-hidden="true">
       <div style="position:fixed;inset:0;background:rgba(31,26,51,.66);display:grid;place-items:center;z-index:1000">
-        <div class="card" style="max-width:400px">
-          <h3 id="client-name"></h3>
-          <p class="mini" id="client-company"></p>
-          <p class="mini" id="client-email"></p>
-          <p class="mini" id="client-phone"></p>
-          <p class="mini">Stage: <span id="client-stage"></span> • Owner: <span id="client-owner"></span></p>
-          <p class="mini">Address:</p>
-          <div id="client-address" contenteditable class="input" style="margin-bottom:6px"></div>
-          <p class="mini"><a id="client-map" href="#" target="_blank">View on map</a></p>
-          <p class="mini" style="margin-top:6px">Follow-up Date:</p>
-          <input type="date" id="client-followup" class="input" style="margin-bottom:6px" />
-          <p class="mini" style="margin-top:6px">Success Definition:</p>
-          <textarea id="client-success" class="input" placeholder="Define success" style="margin-top:6px"></textarea>
-          <textarea id="client-notes" class="input" placeholder="Notes" style="margin-top:6px"></textarea>
-          <div class="linkrow" style="margin-top:10px;justify-content:center">
+        <div style="background:var(--bg);padding:20px;border-radius:14px;max-width:900px;width:90%;max-height:90vh;overflow:auto">
+          <h2>Person Profile</h2>
+          <p class="mini muted">Details about this person and how they interact with the org, plus which orientations and trainings and any events they were involved in.</p>
+          <div class="grid" style="grid-template-columns:2fr 1fr;gap:16px">
+            <div class="card">
+              <div class="kpi" style="justify-content:space-between">
+                <h3>Details</h3>
+                <div class="linkrow">
+                  <button class="btn link" id="client-download">Download</button>
+                  <button class="btn link" id="client-edit">Edit</button>
+                </div>
+              </div>
+              <p><strong id="client-name"></strong></p>
+              <p class="mini" id="client-company"></p>
+              <p class="mini" id="client-email"></p>
+              <p class="mini" id="client-phone"></p>
+              <p class="mini">Stage: <span id="client-stage"></span> • Owner: <span id="client-owner"></span></p>
+              <p class="mini">Address:</p>
+              <div id="client-address" contenteditable class="input" style="margin-bottom:6px"></div>
+              <p class="mini"><a id="client-map" href="#" target="_blank">View on map</a></p>
+              <p class="mini" style="margin-top:6px">Follow-up Date:</p>
+              <input type="date" id="client-followup" class="input" style="margin-bottom:6px" />
+              <p class="mini" style="margin-top:6px">Success Definition:</p>
+              <textarea id="client-success" class="input" placeholder="Define success"></textarea>
+              <textarea id="client-notes" class="input" placeholder="Notes" style="margin-top:6px"></textarea>
+            </div>
+            <div class="grid" style="gap:16px">
+              <div class="card">
+                <h3>Metrics</h3>
+                <p class="mini">No associated metrics</p>
+              </div>
+              <div class="card">
+                <h3>Highlights & Alerts</h3>
+                <p class="mini">None</p>
+              </div>
+            </div>
+          </div>
+          <div class="grid" style="grid-template-columns:repeat(3,1fr);gap:16px;margin-top:16px">
+            <div class="card">
+              <h3>Orientations & Trainings</h3>
+              <p class="mini">No trainings associated</p>
+            </div>
+            <div class="card">
+              <h3>Associated Events</h3>
+              <p class="mini">No events associated</p>
+            </div>
+            <div class="card">
+              <h3>Workflow List</h3>
+              <p class="mini">No workflows assigned</p>
+            </div>
+          </div>
+          <div class="card" style="margin-top:16px">
+            <h3>Document Center</h3>
+            <p class="mini">No files uploaded</p>
+          </div>
+          <div class="linkrow" style="margin-top:16px;justify-content:center">
             <button class="btn secondary" id="client-close">Close</button>
           </div>
         </div>
@@ -810,16 +851,26 @@
       const clientSuccess = document.getElementById('client-success');
       const clientMap = document.getElementById('client-map');
       let currentClientRow = null;
-      function openClientModal(row){
+      function openClientModal(row, isCompany=false){
         currentClientRow = row;
         const cells = row.children;
-        clientNameEl.textContent = cells[0].textContent.trim();
-        clientCompany.textContent = cells[1].textContent.trim();
-        const email = cells[2].textContent.trim();
-        clientEmail.innerHTML = `<a href="mailto:${email}">${email}</a>`;
-        clientPhone.textContent = cells[3].textContent.trim();
-        clientStage.textContent = cells[4].querySelector('select').value;
-        clientOwner.textContent = cells[5].textContent.trim();
+        if(isCompany){
+          clientNameEl.textContent = cells[0].textContent.trim();
+          clientCompany.textContent = `Industry: ${cells[1].textContent.trim()}`;
+          const site = cells[2].textContent.trim();
+          clientEmail.innerHTML = `<a href="http://${site}" target="_blank">${site}</a>`;
+          clientPhone.textContent = '';
+          clientStage.textContent = cells[3].querySelector('select').value;
+          clientOwner.textContent = cells[4].textContent.trim();
+        }else{
+          clientNameEl.textContent = cells[0].textContent.trim();
+          clientCompany.textContent = cells[1].textContent.trim();
+          const email = cells[2].textContent.trim();
+          clientEmail.innerHTML = `<a href="mailto:${email}">${email}</a>`;
+          clientPhone.textContent = cells[3].textContent.trim();
+          clientStage.textContent = cells[4].querySelector('select').value;
+          clientOwner.textContent = cells[5].textContent.trim();
+        }
         clientAddress.textContent = row.dataset.address || '';
         clientNotes.value = row.dataset.notes || '';
         clientFollowup.value = row.dataset.followup || '';
@@ -831,6 +882,11 @@
         const row = e.target.closest('tr');
         if(!row) return;
         openClientModal(row);
+      });
+      companyTable.addEventListener('dblclick', e=>{
+        const row = e.target.closest('tr');
+        if(!row) return;
+        openClientModal(row, true);
       });
       clientAddress.addEventListener('blur',()=>{
         clientMap.href = 'https://www.google.com/maps?q='+encodeURIComponent(clientAddress.textContent.trim());

--- a/index.html
+++ b/index.html
@@ -166,14 +166,14 @@
         <div class="card">
           <div class="kpi">
             <h3>Revenue Generated</h3>
-            <p id="kpi-revenue">$0</p>
+            <p id="kpi-revenue">$3760</p>
           </div>
           <canvas id="revenue-chart" width="320" height="120" class="chart" aria-label="Revenue bar chart"></canvas>
         </div>
         <div class="card">
           <div class="kpi">
             <h3>Time Saved</h3>
-            <p id="kpi-time">0h</p>
+            <p id="kpi-time">22 Hrs</p>
           </div>
           <canvas id="time-chart" width="320" height="120" class="chart" aria-label="Time saved line chart"></canvas>
         </div>

--- a/index.html
+++ b/index.html
@@ -457,7 +457,6 @@
           <input type="date" class="input" id="new-project-due" style="flex:1" />
           <button class="btn" id="add-project">Add</button>
         </div>
-        <div id="project-detail" class="hidden"></div>
       </div>
       <div class="card" style="margin-top:16px;text-align:center">
         <button class="btn" id="start-survey">🌱 Employee Wellness Survey</button>
@@ -565,6 +564,34 @@
           <textarea id="client-notes" class="input" placeholder="Notes" style="margin-top:6px"></textarea>
           <div class="linkrow" style="margin-top:10px;justify-content:center">
             <button class="btn secondary" id="client-close">Close</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- PROJECT DETAIL MODAL -->
+    <section id="project-modal" class="hidden" aria-hidden="true">
+      <div style="position:fixed;inset:0;background:rgba(31,26,51,.66);display:grid;place-items:center;z-index:1000">
+        <div class="card" style="max-width:400px">
+          <h3 id="project-title"></h3>
+          <p class="mini">Owner: <span id="project-owner"></span> • Status: <span id="project-status"></span></p>
+          <p class="mini">Due: <span id="project-due"></span></p>
+          <div class="grid grid-3 mini" style="margin:12px 0">
+            <div>
+              <h4>To Do</h4>
+              <ul id="project-todo"></ul>
+            </div>
+            <div>
+              <h4>In Progress</h4>
+              <ul id="project-progress"></ul>
+            </div>
+            <div>
+              <h4>Done</h4>
+              <ul id="project-done"></ul>
+            </div>
+          </div>
+          <div class="linkrow" style="justify-content:center;margin-top:10px">
+            <button class="btn secondary" id="project-close">Close</button>
           </div>
         </div>
       </div>
@@ -1518,36 +1545,39 @@
       openTaskDetails(taskEl);
     });
 
-    // Project table search and detail toggle
+    // Project table search and modal
     const projectSearch = document.getElementById('project-search');
     const projectTableBody = document.querySelector('#project-table tbody');
-    const projectDetail = document.getElementById('project-detail');
     const addProjectBtn = document.getElementById('add-project');
+    const projectModal = document.getElementById('project-modal');
+    const projectClose = document.getElementById('project-close');
+    const projectTitle = document.getElementById('project-title');
+    const projectOwner = document.getElementById('project-owner');
+    const projectStatus = document.getElementById('project-status');
+    const projectDue = document.getElementById('project-due');
+    const projectTodo = document.getElementById('project-todo');
+    const projectProgress = document.getElementById('project-progress');
+    const projectDone = document.getElementById('project-done');
+
     const projectData = {
       onboard:{tasks:{todo:['Send welcome email'],progress:['Compile documents'],done:['Kickoff call']},prompts:['Draft onboarding checklist','Suggest welcome email text','Outline first-week tasks']},
       blue:{tasks:{todo:['Review requirements'],progress:['Write proposal'],done:['Initial consultation']},prompts:['Summarize client needs','Draft proposal outline','Plan follow-up steps']},
       acme:{tasks:{todo:['Schedule kickoff'],progress:['Prepare agenda'],done:['Signed contract']},prompts:['Create kickoff agenda','Identify key stakeholders','Estimate project timeline']}
     };
-    let currentProject=null;
-    function renderProject(key){
-      const data = projectData[key];
-      if(!data){projectDetail.classList.add('hidden');currentProject=null;return;}
-      if(currentProject===key){projectDetail.classList.add('hidden');currentProject=null;return;}
-      currentProject=key;
-      projectDetail.innerHTML=`
-        <div class="kanban">
-          <div class="column"><h4>To Do</h4>${data.tasks.todo.map(t=>`<div class="task"><strong>${t}</strong></div>`).join('')}</div>
-          <div class="column"><h4>In Progress</h4>${data.tasks.progress.map(t=>`<div class="task"><strong>${t}</strong></div>`).join('')}</div>
-          <div class="column"><h4>Done</h4>${data.tasks.done.map(t=>`<div class="task"><strong>${t}</strong></div>`).join('')}</div>
-        </div>
-        <div class="assistant" style="margin-top:12px">
-          <div class="prompt">${data.prompts[0]}</div>
-          <div class="prompt">${data.prompts[1]}</div>
-          <div class="prompt">${data.prompts[2]}</div>
-        </div>
-      `;
-      projectDetail.classList.remove('hidden');
+
+    function openProjectModal(row){
+      const cells=[...row.children];
+      projectTitle.textContent=cells[0].textContent.trim();
+      projectOwner.textContent=cells[1].textContent.trim();
+      projectStatus.textContent=cells[2].textContent.trim();
+      projectDue.textContent=cells[3].textContent.trim();
+      const data=projectData[row.dataset.key]||{tasks:{todo:[],progress:[],done:[]}};
+      projectTodo.innerHTML=data.tasks.todo.map(t=>`<li>${t}</li>`).join('')||'<li class="muted">None</li>';
+      projectProgress.innerHTML=data.tasks.progress.map(t=>`<li>${t}</li>`).join('')||'<li class="muted">None</li>';
+      projectDone.innerHTML=data.tasks.done.map(t=>`<li>${t}</li>`).join('')||'<li class="muted">None</li>';
+      projectModal.classList.remove('hidden');
     }
+
     if(projectSearch){
       projectSearch.addEventListener('input',()=>{
         const q=projectSearch.value.toLowerCase();
@@ -1566,6 +1596,7 @@
         const due=document.getElementById('new-project-due').value;
         if(!name){alert('Project name required');return;}
         const key=name.toLowerCase().replace(/[^a-z0-9]+/g,'-')+Date.now();
+        projectData[key]={tasks:{todo:[],progress:[],done:[]},prompts:[]};
         const tr=document.createElement('tr');
         tr.dataset.key=key;
         tr.tabIndex=0;
@@ -1580,21 +1611,24 @@
           const row=e.target.closest('tr[data-key]');
           if(row){
             delete projectData[row.dataset.key];
-            if(currentProject===row.dataset.key){projectDetail.classList.add('hidden');currentProject=null;}
             row.remove();
           }
           return;
         }
+      });
+      projectTableBody.addEventListener('dblclick',e=>{
         const row=e.target.closest('tr[data-key]');
-        if(row){renderProject(row.dataset.key);}
+        if(row){openProjectModal(row);}
       });
       projectTableBody.addEventListener('keydown',e=>{
         if(e.key==='Enter'){
           const row=e.target.closest('tr[data-key]');
-          if(row){renderProject(row.dataset.key);}
+          if(row){openProjectModal(row);}
         }
       });
     }
+    if(projectClose){ projectClose.addEventListener('click',()=>projectModal.classList.add('hidden')); }
+    if(projectModal){ projectModal.addEventListener('click',e=>{ if(e.target===projectModal.firstElementChild){ projectModal.classList.add('hidden'); } }); }
 
     // Done for the Day overlay
     const doneBtn = document.getElementById('done-day');

--- a/index.html
+++ b/index.html
@@ -558,6 +558,10 @@
           <p class="mini">Address:</p>
           <div id="client-address" contenteditable class="input" style="margin-bottom:6px"></div>
           <p class="mini"><a id="client-map" href="#" target="_blank">View on map</a></p>
+          <p class="mini" style="margin-top:6px">Follow-up Date:</p>
+          <input type="date" id="client-followup" class="input" style="margin-bottom:6px" />
+          <p class="mini" style="margin-top:6px">Success Definition:</p>
+          <textarea id="client-success" class="input" placeholder="Define success" style="margin-top:6px"></textarea>
           <textarea id="client-notes" class="input" placeholder="Notes" style="margin-top:6px"></textarea>
           <div class="linkrow" style="margin-top:10px;justify-content:center">
             <button class="btn secondary" id="client-close">Close</button>
@@ -686,6 +690,7 @@
         tr.innerHTML=`<td contenteditable>${name}</td><td contenteditable>${comp}</td><td contenteditable>${email}</td><td contenteditable>${phone}</td><td data-stage>${stageDropdown(stage)}</td><td contenteditable>${owner}</td>`;
         clientTable.appendChild(tr);
         addToPipeline(name, comp, stage);
+        openClientModal(tr);
         ['new-name','new-company','new-email','new-phone','new-owner'].forEach(id=>document.getElementById(id).value='');
       });
     }
@@ -784,13 +789,13 @@
       const clientOwner = document.getElementById('client-owner');
       const clientAddress = document.getElementById('client-address');
       const clientNotes = document.getElementById('client-notes');
+      const clientFollowup = document.getElementById('client-followup');
+      const clientSuccess = document.getElementById('client-success');
       const clientMap = document.getElementById('client-map');
       let currentClientRow = null;
-      clientTable.addEventListener('click', e=>{
-        const nameCell = e.target.closest('.client-name');
-        if(!nameCell) return;
-        currentClientRow = nameCell.parentElement;
-        const cells = currentClientRow.children;
+      function openClientModal(row){
+        currentClientRow = row;
+        const cells = row.children;
         clientNameEl.textContent = cells[0].textContent.trim();
         clientCompany.textContent = cells[1].textContent.trim();
         const email = cells[2].textContent.trim();
@@ -798,10 +803,17 @@
         clientPhone.textContent = cells[3].textContent.trim();
         clientStage.textContent = cells[4].querySelector('select').value;
         clientOwner.textContent = cells[5].textContent.trim();
-        clientAddress.textContent = currentClientRow.dataset.address || '';
-        clientNotes.value = currentClientRow.dataset.notes || '';
+        clientAddress.textContent = row.dataset.address || '';
+        clientNotes.value = row.dataset.notes || '';
+        clientFollowup.value = row.dataset.followup || '';
+        clientSuccess.value = row.dataset.success || '';
         clientMap.href = 'https://www.google.com/maps?q='+encodeURIComponent(clientAddress.textContent.trim());
         clientModal.classList.remove('hidden');
+      }
+      clientTable.addEventListener('dblclick', e=>{
+        const row = e.target.closest('tr');
+        if(!row) return;
+        openClientModal(row);
       });
       clientAddress.addEventListener('blur',()=>{
         clientMap.href = 'https://www.google.com/maps?q='+encodeURIComponent(clientAddress.textContent.trim());
@@ -810,6 +822,8 @@
         if(!currentClientRow) return;
         currentClientRow.dataset.address = clientAddress.textContent.trim();
         currentClientRow.dataset.notes = clientNotes.value.trim();
+        currentClientRow.dataset.followup = clientFollowup.value;
+        currentClientRow.dataset.success = clientSuccess.value.trim();
       }
       if(clientClose){ clientClose.addEventListener('click',()=>{ saveClientDetails(); clientModal.classList.add('hidden'); }); }
       if(clientModal){ clientModal.addEventListener('click', e=>{ if(e.target===clientModal.firstElementChild){ saveClientDetails(); clientModal.classList.add('hidden'); } }); }

--- a/index.html
+++ b/index.html
@@ -414,14 +414,39 @@
         <input class="input" id="project-search" placeholder="Search projects" style="margin-bottom:8px" />
         <table class="table" id="project-table" role="table">
           <thead>
-            <tr><th>Project</th><th>Owner</th><th>Status</th><th>Due</th></tr>
+            <tr><th>Project</th><th>Owner</th><th>Status</th><th>Due</th><th></th></tr>
           </thead>
           <tbody>
-            <tr data-key="onboard" tabindex="0"><td contenteditable>Launch Onboarding Flow</td><td contenteditable>Nate</td><td contenteditable>In Progress</td><td contenteditable>2024-06-15</td></tr>
-            <tr data-key="blue" tabindex="0"><td contenteditable>Proposal for Blue Sky</td><td contenteditable>Priya</td><td contenteditable>Proposal Sent</td><td contenteditable>2024-06-20</td></tr>
-            <tr data-key="acme" tabindex="0"><td contenteditable>Kickoff – Acme Co.</td><td contenteditable>Jordan</td><td contenteditable>Planning</td><td contenteditable>2024-06-30</td></tr>
+            <tr data-key="onboard" tabindex="0">
+              <td contenteditable>Launch Onboarding Flow</td>
+              <td contenteditable>Nate</td>
+              <td contenteditable>In Progress</td>
+              <td contenteditable>2024-06-15</td>
+              <td><button class="btn link remove-project">Remove</button></td>
+            </tr>
+            <tr data-key="blue" tabindex="0">
+              <td contenteditable>Proposal for Blue Sky</td>
+              <td contenteditable>Priya</td>
+              <td contenteditable>Proposal Sent</td>
+              <td contenteditable>2024-06-20</td>
+              <td><button class="btn link remove-project">Remove</button></td>
+            </tr>
+            <tr data-key="acme" tabindex="0">
+              <td contenteditable>Kickoff – Acme Co.</td>
+              <td contenteditable>Jordan</td>
+              <td contenteditable>Planning</td>
+              <td contenteditable>2024-06-30</td>
+              <td><button class="btn link remove-project">Remove</button></td>
+            </tr>
           </tbody>
         </table>
+        <div class="add-task-row">
+          <input class="input" id="new-project-name" placeholder="Project name" style="flex:2" />
+          <input class="input" id="new-project-owner" placeholder="Owner" style="flex:1" />
+          <input class="input" id="new-project-status" placeholder="Status" style="flex:1" />
+          <input type="date" class="input" id="new-project-due" style="flex:1" />
+          <button class="btn" id="add-project">Add</button>
+        </div>
         <div id="project-detail" class="hidden"></div>
       </div>
       <div class="card" style="margin-top:16px;text-align:center">
@@ -1459,6 +1484,7 @@
     const projectSearch = document.getElementById('project-search');
     const projectTableBody = document.querySelector('#project-table tbody');
     const projectDetail = document.getElementById('project-detail');
+    const addProjectBtn = document.getElementById('add-project');
     const projectData = {
       onboard:{tasks:{todo:['Send welcome email'],progress:['Compile documents'],done:['Kickoff call']},prompts:['Draft onboarding checklist','Suggest welcome email text','Outline first-week tasks']},
       blue:{tasks:{todo:['Review requirements'],progress:['Write proposal'],done:['Initial consultation']},prompts:['Summarize client needs','Draft proposal outline','Plan follow-up steps']},
@@ -1488,13 +1514,39 @@
       projectSearch.addEventListener('input',()=>{
         const q=projectSearch.value.toLowerCase();
         [...projectTableBody.querySelectorAll('tr')].forEach(tr=>{
-          const match=[...tr.children].some(td=>td.textContent.toLowerCase().includes(q));
+          const cells=[...tr.querySelectorAll('td')].slice(0,4);
+          const match=cells.some(td=>td.textContent.toLowerCase().includes(q));
           tr.style.display=match?'':'none';
         });
       });
     }
+    if(addProjectBtn){
+      addProjectBtn.addEventListener('click',()=>{
+        const name=document.getElementById('new-project-name').value.trim();
+        const owner=document.getElementById('new-project-owner').value.trim();
+        const status=document.getElementById('new-project-status').value.trim();
+        const due=document.getElementById('new-project-due').value;
+        if(!name){alert('Project name required');return;}
+        const key=name.toLowerCase().replace(/[^a-z0-9]+/g,'-')+Date.now();
+        const tr=document.createElement('tr');
+        tr.dataset.key=key;
+        tr.tabIndex=0;
+        tr.innerHTML=`<td contenteditable>${name}</td><td contenteditable>${owner}</td><td contenteditable>${status}</td><td contenteditable>${due}</td><td><button class="btn link remove-project">Remove</button></td>`;
+        projectTableBody.appendChild(tr);
+        ['new-project-name','new-project-owner','new-project-status','new-project-due'].forEach(id=>document.getElementById(id).value='');
+      });
+    }
     if(projectTableBody){
       projectTableBody.addEventListener('click',e=>{
+        if(e.target.classList.contains('remove-project')){
+          const row=e.target.closest('tr[data-key]');
+          if(row){
+            delete projectData[row.dataset.key];
+            if(currentProject===row.dataset.key){projectDetail.classList.add('hidden');currentProject=null;}
+            row.remove();
+          }
+          return;
+        }
         const row=e.target.closest('tr[data-key]');
         if(row){renderProject(row.dataset.key);}
       });

--- a/index.html
+++ b/index.html
@@ -535,9 +535,11 @@
       <section id="task-modal" class="hidden" aria-hidden="true">
       <div style="position:fixed;inset:0;background:rgba(31,26,51,.66);display:grid;place-items:center;z-index:1000">
         <div class="card" style="max-width:360px;text-align:center">
-          <h3 id="modal-title"></h3>
+          <input id="modal-title" class="input" placeholder="Task title" style="margin-bottom:8px" />
           <p class="mini" style="margin-bottom:4px">Due:</p>
           <input type="datetime-local" id="modal-due" class="input" style="margin-bottom:8px" />
+          <p class="mini" id="modal-client-label" style="margin-bottom:4px;display:none">Assign to client:</p>
+          <select id="modal-client" class="input" style="margin-bottom:8px;display:none"></select>
           <textarea id="modal-note" class="input" placeholder="Add notes" style="margin:8px 0"></textarea>
           <div id="modal-contact" class="mini" style="margin-bottom:8px"></div>
           <button class="btn secondary" id="modal-close">Close</button>
@@ -884,7 +886,8 @@
         div.className = 'task'+(t.checked?' checked':'');
         div.dataset.id = t.id;
         div.draggable = true;
-        div.innerHTML = `<div style=\"display:flex;align-items:center;gap:6px;\"><div class=\"checkbox ${t.checked?'checked':''}\" data-check></div><div contenteditable class=\"task-title\">${t.title}</div></div><div class=\"mini\">Due: <input type=\"date\" class=\"task-due\" value=\"${t.due||''}\" /></div>`;
+        const clientName = t.clientId ? (clientTable.querySelector(`#${t.clientId} .client-name`)?.textContent.trim() || '') : '';
+        div.innerHTML = `<div style=\"display:flex;align-items:center;gap:6px;\"><div class=\"checkbox ${t.checked?'checked':''}\" data-check></div><div contenteditable class=\"task-title\">${t.title}</div></div><div class=\"mini\">Due: <input type=\"date\" class=\"task-due\" value=\"${t.due||''}\" /></div>${clientName?`<div class=\\"mini\\">Client: ${clientName}</div>`:''}`;
         col.appendChild(div);
       });
       updateInsights();
@@ -1449,6 +1452,8 @@
       const modalNote = document.getElementById('modal-note');
       const modalContact = document.getElementById('modal-contact');
       const modalClose = document.getElementById('modal-close');
+      const modalClient = document.getElementById('modal-client');
+      const modalClientLabel = document.getElementById('modal-client-label');
       function findCRMContactFromTitle(title){
         const match = title.match(/(?:Call|Email):\s*([^()]+)/i);
         if(match){
@@ -1466,7 +1471,13 @@
         const dueVal = modalDue.value;
         if(source==='kanban'){
           const t = tasks.find(x=>x.id===Number(id));
-          if(t){ t.due = dueVal?dueVal.split('T')[0]:''; saveTasks(); renderTasks(); }
+          if(t){
+            t.title = modalTitle.value.trim();
+            t.due = dueVal?dueVal.split('T')[0]:'';
+            t.clientId = modalClient.value;
+            saveTasks();
+            renderTasks();
+          }
         }else if(source==='daily'){
           const d = dailyTasks.find(x=>x.id===Number(id));
           if(d){ d.due = dueVal?dueVal.split('T')[0]:''; saveDaily(); renderDaily(); }
@@ -1480,37 +1491,59 @@
         taskModal.addEventListener('click', e=>{ if(e.target===taskModal.firstElementChild){ saveTaskModal(); } });
       }
       if(modalClose){ modalClose.addEventListener('click', saveTaskModal); }
+    function updateModalContactFromSelect(){
+      if(!modalClient) return;
+      const id = modalClient.value;
+      if(id){
+        const row = clientTable.querySelector(`#${id}`);
+        const name = row ? row.querySelector('.client-name').textContent.trim() : '';
+        modalContact.innerHTML = name ? `<a href="#page-crm" class="crm-link" data-target="${id}">View contact: ${name}</a>` : '';
+      }else{
+        modalContact.innerHTML = '';
+      }
+    }
+    if(modalClient){ modalClient.addEventListener('change', updateModalContactFromSelect); }
+
     function openTaskDetails(taskEl){
-      let title='', due='', source='', id='', article='';
+      let title='', due='', source='', id='', article='', key='';
+      let t=null;
       if(taskEl.dataset.id){
-        const t = tasks.find(x=>x.id===Number(taskEl.dataset.id));
-        if(t){ title=t.title; due=t.due||''; source='kanban'; id=t.id; }
+        t = tasks.find(x=>x.id===Number(taskEl.dataset.id));
+        if(t){ title=t.title; due=t.due||''; source='kanban'; id=t.id; key='task-'+id; }
       }else if(taskEl.closest('#upcoming-list')){
         const idx = Number(taskEl.dataset.index);
         const u = upcoming[idx];
-        title = u.title; due = u.time; source='upcoming'; id=idx;
+        title = u.title; due = u.time; source='upcoming'; id=idx; key=title;
       }else if(taskEl.closest('#page-daily')){
         const d = dailyTasks.find(x=>x.id===Number(taskEl.dataset.id));
-        if(d){ title=d.title; due=d.due||''; source='daily'; id=d.id; article=d.link; }
+        if(d){ title=d.title; due=d.due||''; source='daily'; id=d.id; article=d.link; key='task-'+id; }
       }else if(taskEl.closest('#pipeline')){
         title = taskEl.textContent.trim();
         due = taskEl.parentElement.dataset.stage || '';
         source='pipeline';
+        key=title;
       }
       if(title){
-        modalTitle.textContent=title;
+        modalTitle.value=title;
         modalDue.value = due ? (due.includes('T')?due:due+'T00:00') : '';
-        modalNote.value = taskNotes[title] || '';
-        const contact = findCRMContactFromTitle(title);
+        modalNote.value = taskNotes[key] || '';
         let html='';
-        if(contact){
-          html += `<a href="#page-crm" class="crm-link" data-target="${contact.id}">View contact: ${contact.name}</a>`;
+        if(source==='kanban'){
+          modalTitle.disabled = false;
+          modalClient.innerHTML = '<option value="">Unassigned</option>' + [...clientTable.querySelectorAll('tr')]
+            .map(r=>`<option value="${r.id}">${r.querySelector('.client-name').textContent.trim()}</option>`).join('');
+          modalClient.value = t && t.clientId ? t.clientId : '';
+          modalClientLabel.style.display = modalClient.style.display = '';
+          updateModalContactFromSelect();
+        }else{
+          modalTitle.disabled = true;
+          modalClientLabel.style.display = modalClient.style.display = 'none';
+          const contact = findCRMContactFromTitle(title);
+          if(contact){ html += `<a href="#page-crm" class="crm-link" data-target="${contact.id}">View contact: ${contact.name}</a>`; }
+          if(article){ html += `${html?'<br/>':''}<a href="${article}" target="_blank">Wellness article</a>`; }
+          modalContact.innerHTML = html;
         }
-        if(article){
-          html += `${html?'<br/>':''}<a href="${article}" target="_blank">Wellness article</a>`;
-        }
-        modalContact.innerHTML = html;
-        taskModal.dataset.key = title;
+        taskModal.dataset.key = key;
         taskModal.dataset.source = source;
         taskModal.dataset.id = id;
         taskModal.classList.remove('hidden');

--- a/index.html
+++ b/index.html
@@ -163,14 +163,18 @@
         </div>
       </div>
       <div class="grid grid-2" style="margin-top:16px">
-        <div class="card kpi">
-          <h3>Revenue Generated</h3>
-          <p id="kpi-revenue">$0</p>
+        <div class="card">
+          <div class="kpi">
+            <h3>Revenue Generated</h3>
+            <p id="kpi-revenue">$0</p>
+          </div>
           <canvas id="revenue-chart" width="320" height="120" class="chart" aria-label="Revenue bar chart"></canvas>
         </div>
-        <div class="card kpi">
-          <h3>Time Saved</h3>
-          <p id="kpi-time">0h</p>
+        <div class="card">
+          <div class="kpi">
+            <h3>Time Saved</h3>
+            <p id="kpi-time">0h</p>
+          </div>
           <canvas id="time-chart" width="320" height="120" class="chart" aria-label="Time saved line chart"></canvas>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -689,19 +689,7 @@
         col.appendChild(div);
       }
     }
-    // click to advance pipeline stage
-    if(pipelineBoard){
-      pipelineBoard.addEventListener('click',e=>{
-        const card=e.target.closest('.task');
-        if(!card) return;
-        const stages=['Lead','Proposal','Won'];
-        const current=card.parentElement.dataset.stage;
-        let idx=stages.indexOf(current);
-        idx=(idx+1)%stages.length;
-        const nextCol=pipelineBoard.querySelector(`.column[data-stage='${stages[idx]}']`);
-        if(nextCol) nextCol.appendChild(card);
-      });
-    }
+    // Pipeline cards no longer advance stages on click; movement occurs through drag and drop only
 
     // Clients table
     const addClientBtn = document.getElementById('add-client');

--- a/index.html
+++ b/index.html
@@ -326,6 +326,16 @@
             </select>
             <button class="btn" id="add-template">Add</button>
           </div>
+          <div class="add-task-row" style="margin:8px 0">
+            <input class="input" id="custom-task-title" placeholder="Custom task title" style="flex:2" />
+            <input type="date" class="input" id="custom-task-due" style="flex:1" />
+            <select id="custom-task-status" class="input" style="flex:1">
+              <option value="todo">To Do</option>
+              <option value="progress">In Progress</option>
+              <option value="done">Done</option>
+            </select>
+            <button class="btn" id="add-custom-task">Add Task</button>
+          </div>
           <div class="kanban">
             <div class="column" data-status="todo">
               <h4>To Do</h4>
@@ -878,6 +888,20 @@
           const due = new Date(); due.setDate(due.getDate()+7);
           addTask('todo', title, due.toISOString().split('T')[0]);
           templateSelect.value='';
+        });
+      }
+
+      const addCustomTaskBtn = document.getElementById('add-custom-task');
+      if(addCustomTaskBtn){
+        addCustomTaskBtn.addEventListener('click', ()=>{
+          const title = document.getElementById('custom-task-title').value.trim();
+          const due = document.getElementById('custom-task-due').value;
+          const status = document.getElementById('custom-task-status').value;
+          if(!title) return;
+          addTask(status, title, due);
+          document.getElementById('custom-task-title').value='';
+          document.getElementById('custom-task-due').value='';
+          document.getElementById('custom-task-status').value='todo';
         });
       }
 


### PR DESCRIPTION
## Summary
- Add KPI cards for revenue generated and time saved on dashboard
- Display today's tasks from Kanban board as bullet list
- Populate dashboard task list automatically from Kanban tasks

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -H "Content-Type: text/html; charset=utf-8" --data-binary @index.html https://validator.w3.org/nu/?out=text` *(fails: CONNECT tunnel failed, response 403)*
- `npx --yes html-validate index.html` *(fails: 146 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ab5a2cbb9483318dba87a3bd50169c