### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,20 @@
       padding:8px 12px;
       cursor:pointer;
     }
+    /* Responsive design for small screens */
+    @media (max-width: 768px){
+      .topbar{flex-direction:column;align-items:flex-start;gap:8px}
+      .topbar nav{width:100%}
+      .search{margin-left:0;width:100%}
+      #help-btn{align-self:flex-end}
+      .grid-3,
+      .grid-2,
+      .crm-grid,
+      .cta-grid,
+      .kanban{grid-template-columns:1fr}
+      .column{min-width:auto}
+      #sim-widget{width:calc(100% - 40px);left:20px;right:20px}
+    }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- Add CSS media query to adapt layout for small screens
- Stack topbar elements and collapse grid layouts on mobile
- Adjust chat widget width for better fit on phones

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae0320d4b483319d3e05525b9ad6e6